### PR TITLE
[AZINTS] use type check for ci and pre-commit, and only install deps in ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,10 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.9.0'
+- repo: local
   hooks:
-  -   id: mypy
+    - id: mypy
+      name: Type Check
+      entry: ci/tasks/type-check.sh
+      language: system
+      types: [python]

--- a/ci/tasks/type-check.sh
+++ b/ci/tasks/type-check.sh
@@ -3,7 +3,8 @@
 set -euxo pipefail
 
 # install mypy
-pip install mypy==1.9.0
-pip install -r diagnostic_settings_task/requirements.txt -r resources_task/requirements.txt
+if [ "${CI:-}" == 'true' ]; then
+    pip install mypy==1.9.0 -r diagnostic_settings_task/requirements.txt -r resources_task/requirements.txt
+fi
 
 python -m mypy diagnostic_settings_task resources_task


### PR DESCRIPTION
Uses CI mypy (unsandboxed) while running it in pre-commit