### PR TITLE
[AZINT-2686]Rename Metric Blob Entry Variable to be more Descriptive

### DIFF
--- a/control_plane/cache/metric_blob_cache.py
+++ b/control_plane/cache/metric_blob_cache.py
@@ -13,20 +13,20 @@ class MetricBlobEntry(TypedDict, total=True):
 
     timestamp: float
     "a UNIX timestamp when metric was created"
-    runtimeSeconds: float
-    "runtimeSeconds: The number of seconds taken for the forwarder to run"
-    resourceLogVolumes: dict[str, int]
-    "resourceLogVolumes: A mapping of resource id ->log volume in bytes"
+    runtime_seconds: float
+    "The number of seconds taken for the forwarder to run"
+    resource_log_volume: dict[str, int]
+    "A mapping of resource id ->log volume in bytes"
 
 
 METRIC_BLOB_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "timestamp": {"type": "number"},
-        "runtimeSeconds": {"type": "number"},
-        "resourceLogVolumes": {"type": "object", "additionalProperties": {"type": "number"}},
+        "runtime_seconds": {"type": "number"},
+        "resource_log_volume": {"type": "object", "additionalProperties": {"type": "number"}},
     },
-    "required": ["timestamp", "runtimeSeconds", "resourceLogVolumes"],
+    "required": ["timestamp", "runtime_seconds", "resource_log_volume"],
     "additionalProperties": False,
 }
 

--- a/control_plane/cache/tests/test_metric_blob_cache.py
+++ b/control_plane/cache/tests/test_metric_blob_cache.py
@@ -18,14 +18,14 @@ class TestMetricBlobCache(TestCase):
         blob_dict_str = dumps(
             {
                 "timestamp": self.current_time,
-                "runtimeSeconds": 2.11,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.11,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             }
         )
         expected_dict = {
             "timestamp": self.current_time,
-            "runtimeSeconds": 2.11,
-            "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+            "runtime_seconds": 2.11,
+            "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
         }
         returned_dict = deserialize_blob_metric_entry(blob_dict_str, self.oldest_legal_time.timestamp())
         self.assertIsNotNone(returned_dict)
@@ -36,8 +36,8 @@ class TestMetricBlobCache(TestCase):
         blob_dict_str = dumps(
             {
                 "timestamp": self.old_time,
-                "runtimeSeconds": 2.11,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.11,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             }
         )
         returned_dict = deserialize_blob_metric_entry(blob_dict_str, self.oldest_legal_time.timestamp())
@@ -47,14 +47,14 @@ class TestMetricBlobCache(TestCase):
         blob_dict_str = dumps(
             {
                 "timestamp": self.oldest_legal_time.timestamp(),
-                "runtimeSeconds": 2.11,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.11,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             }
         )
         expected_dict = {
             "timestamp": self.oldest_legal_time.timestamp(),
-            "runtimeSeconds": 2.11,
-            "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+            "runtime_seconds": 2.11,
+            "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
         }
         returned_dict = deserialize_blob_metric_entry(blob_dict_str, self.oldest_legal_time.timestamp())
         self.assertIsNotNone(returned_dict)
@@ -64,8 +64,8 @@ class TestMetricBlobCache(TestCase):
     def test_validation_missing_property(self):
         blob_dict_str = dumps(
             {
-                "runtimeSeconds": 2.11,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.11,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             }
         )
         returned_dict = deserialize_blob_metric_entry(blob_dict_str, self.oldest_legal_time.timestamp())
@@ -75,9 +75,9 @@ class TestMetricBlobCache(TestCase):
         blob_dict_str = dumps(
             {
                 "timestamp": self.old_time,
-                "runtimeSeconds": 2.11,
+                "runtime_seconds": 2.11,
                 "hello": "my_friend",
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             }
         )
         returned_dict = deserialize_blob_metric_entry(blob_dict_str, self.oldest_legal_time.timestamp())

--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -354,5 +354,5 @@ class LogForwarderClient(AbstractAsyncContextManager):
     def create_metric_point(self, metric: MetricBlobEntry) -> MetricPoint:
         return MetricPoint(  # type: ignore
             timestamp=int(metric["timestamp"]),
-            value=metric["runtimeSeconds"],
+            value=metric["runtime_seconds"],
         )

--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -281,13 +281,13 @@ class TestLogForwarderClient(AsyncTestCase):
         sample_metric_entry_list: list[MetricBlobEntry] = [
             {
                 "timestamp": 1723040910,
-                "runtimeSeconds": 280,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 280,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
             {
                 "timestamp": 1723040911,
-                "runtimeSeconds": 281,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 281,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
         ]
         self.client.api_instance.submit_metrics.return_value = {}
@@ -325,13 +325,13 @@ class TestLogForwarderClient(AsyncTestCase):
         sample_metric_entry_list: list[MetricBlobEntry] = [
             {
                 "timestamp": 1723040910,
-                "runtimeSeconds": 2.80,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.80,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
             {
                 "timestamp": 1723040911,
-                "runtimeSeconds": 2.81,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.81,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
         ]
 
@@ -345,13 +345,13 @@ class TestLogForwarderClient(AsyncTestCase):
         sample_metric_entry_list: list[MetricBlobEntry] = [
             {
                 "timestamp": 1723040910,
-                "runtimeSeconds": 2.80,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.80,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
             {
                 "timestamp": 1723040911,
-                "runtimeSeconds": 2.81,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.81,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
         ]
         self.client.api_instance.submit_metrics.side_effect = [RequestTimeout(), RequestTimeout(), DEFAULT]
@@ -391,13 +391,13 @@ class TestLogForwarderClient(AsyncTestCase):
         sample_metric_entry_list: list[MetricBlobEntry] = [
             {
                 "timestamp": 1723040910,
-                "runtimeSeconds": 2.80,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.80,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
             {
                 "timestamp": 1723040911,
-                "runtimeSeconds": 2.81,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.81,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
         ]
         self.client.api_instance.submit_metrics.side_effect = RequestTimeout()
@@ -438,13 +438,13 @@ class TestLogForwarderClient(AsyncTestCase):
         sample_metric_entry_list: list[MetricBlobEntry] = [
             {
                 "timestamp": 1723040910,
-                "runtimeSeconds": 2.80,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.80,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
             {
                 "timestamp": 1723040911,
-                "runtimeSeconds": 2.81,
-                "resourceLogVolumes": {"5a095f74c60a": 4, "93a5885365f5": 6},
+                "runtime_seconds": 2.81,
+                "resource_log_volume": {"5a095f74c60a": 4, "93a5885365f5": 6},
             },
         ]
         self.client.api_instance.submit_metrics.side_effect = FakeHttpError(404)
@@ -488,7 +488,7 @@ class TestLogForwarderClient(AsyncTestCase):
         }
         async with self.client as client:
             await client.submit_log_forwarder_metrics(
-                "test", [{"runtimeSeconds": 2.80, "resourceLogVolumes": {}, "timestamp": 1723040910}]
+                "test", [{"runtime_seconds": 2.80, "resource_log_volume": {}, "timestamp": 1723040910}]
             )
 
         self.log.error.assert_called_once_with("oops something went wrong")

--- a/control_plane/tasks/scaling_task.py
+++ b/control_plane/tasks/scaling_task.py
@@ -49,7 +49,7 @@ def is_consistently_over_threshold(metrics: list[MetricBlobEntry], threshold: fl
     if not metrics:
         return False
 
-    return all(metric["runtimeSeconds"] > threshold for metric in metrics)
+    return all(metric["runtime_seconds"] > threshold for metric in metrics)
 
 
 def is_under_threshold(metrics: list[MetricBlobEntry], threshold: float, since: datetime) -> bool:
@@ -215,7 +215,7 @@ class ScalingTask(Task):
         # any forwarders without metrics we should not add more resources to, there may be something wrong
         least_busy_forwarder_id, _ = min(
             forwarder_metrics.items(),
-            key=lambda metrics_by_id: average(*(metric["runtimeSeconds"] for metric in metrics_by_id[1])),
+            key=lambda metrics_by_id: average(*(metric["runtime_seconds"] for metric in metrics_by_id[1])),
         )
 
         self.assignment_cache[subscription_id][region]["resources"].update(

--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -20,8 +20,8 @@ import (
 
 type MetricEntry struct {
 	Timestamp          int64            `json:"timestamp"`
-	RuntimeSeconds     float64          `json:"runtimeSeconds"`
-	ResourceLogVolumes map[string]int32 `json:"resourceLogVolumes"`
+	RuntimeSeconds     float64          `json:"runtime_seconds"`
+	ResourceLogVolumes map[string]int32 `json:"resource_log_volume"`
 }
 
 func getContainers(ctx context.Context, client storage.Client, containerNameCh chan<- string) error {


### PR DESCRIPTION
## Description
We need to rename the key names in the metric blob entries to be more explicit about what they are testing

runtime -> runtime_seconds
The reason for this is to be more explicit in what unit we are measuring and to be consistent with the Python typing

resourceLogAmounts -> resource_log_volume
The reason for this is because we are not counting the number of logs from each forwarder but rather the size of said logs so we need a more descriptive name.

Jira issue: [AZINTS-2686]

## Testing
Manual testing of forwarder.go to validate correct naming and unit tests 


[AZINTS-2686]: https://datadoghq.atlassian.net/browse/AZINTS-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ