### PR TITLE
[AZINTS-2577] prune resources cache

### DIFF
--- a/control_plane/cache/resources_cache.py
+++ b/control_plane/cache/resources_cache.py
@@ -28,3 +28,13 @@ def deserialize_resource_cache(cache_str: str) -> ResourceCache | None:
         return cache
 
     return deserialize_cache(cache_str, RESOURCE_CACHE_SCHEMA, convert_resources_to_set)
+
+
+def prune_resource_cache(cache: ResourceCache) -> None:
+    """Prune the cache by removing empty regions and subscriptions."""
+    for subscription_id, resources_per_region in list(cache.items()):
+        for region, resources in list(resources_per_region.items()):
+            if not resources:
+                del resources_per_region[region]
+        if not resources_per_region:
+            del cache[subscription_id]

--- a/control_plane/cache/tests/test_resources_cache.py
+++ b/control_plane/cache/tests/test_resources_cache.py
@@ -3,7 +3,7 @@ from json import dumps
 from unittest import TestCase
 
 # project
-from cache.resources_cache import deserialize_resource_cache
+from cache.resources_cache import ResourceCache, deserialize_resource_cache, prune_resource_cache
 from cache.tests import sub_id1, sub_id2
 
 
@@ -35,3 +35,18 @@ class TestDeserializeResourceCache(TestCase):
 
     def test_dict_with_some_non_list_values(self):
         self.assert_deserialize_failure(dumps({sub_id1: {"region1": ["r1"]}, sub_id2: {"region2": {"hi": "value"}}}))
+
+    def test_prune_resources_cache_empty(self):
+        cache: ResourceCache = {}
+        prune_resource_cache(cache)
+        self.assertEqual(cache, {})
+
+    def test_prune_resources_cache_empty_subscription(self):
+        cache: ResourceCache = {"sub1": {}, "sub2": {"region1": {"resource1"}}}
+        prune_resource_cache(cache)
+        self.assertEqual(cache, {"sub2": {"region1": {"resource1"}}})
+
+    def test_prune_resources_cache_empty_region(self):
+        cache: ResourceCache = {"sub1": {"region2": set()}, "sub2": {"region1": {"resource1"}}}
+        prune_resource_cache(cache)
+        self.assertEqual(cache, {"sub2": {"region1": {"resource1"}}})

--- a/control_plane/tasks/resources_task.py
+++ b/control_plane/tasks/resources_task.py
@@ -10,7 +10,7 @@ from azure.mgmt.resource.subscriptions.v2021_01_01.aio import SubscriptionClient
 
 # project
 from cache.common import read_cache, write_cache
-from cache.resources_cache import RESOURCE_CACHE_BLOB, ResourceCache, deserialize_resource_cache
+from cache.resources_cache import RESOURCE_CACHE_BLOB, ResourceCache, deserialize_resource_cache, prune_resource_cache
 from tasks.common import now
 from tasks.task import Task
 
@@ -64,6 +64,7 @@ class ResourcesTask(Task):
             self.resource_cache[subscription_id] = resources_per_region
 
     async def write_caches(self) -> None:
+        prune_resource_cache(self.resource_cache)
         if self.resource_cache == self._resource_cache_initial_state:
             log.info("Resources have not changed, no update needed")
             return

--- a/control_plane/tasks/tests/test_resources_task.py
+++ b/control_plane/tasks/tests/test_resources_task.py
@@ -105,7 +105,7 @@ class TestResourcesTask(TaskTestCase):
                 "sub2": {"region1": {"res3"}},
             }
         )
-        self.assertEqual(self.cache, {"sub1": {}, "sub2": {}})
+        self.assertEqual(self.cache, {})
 
     async def test_subscriptions_gone(self):
         self.sub_client.subscriptions.list = Mock(return_value=async_generator())
@@ -149,7 +149,7 @@ class TestResourcesTask(TaskTestCase):
             ),
         }
         await self.run_resources_task({})
-        self.assertEqual(self.cache, {"sub1": {"region1": {"res2"}}, "sub2": {}})
+        self.assertEqual(self.cache, {"sub1": {"region1": {"res2"}}})
 
     async def test_unexpected_failure_skips_cache_write(self):
         write_caches = self.patch("ResourcesTask.write_caches")


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-2577

Prune the resource cache so we make sure we don't write any meaningless diffs.

Say we have a cache that looks like:
```json
{"sub1": {"region2": set()}}
```
this is semantically the same as an empty cache, but because it isnt python `==`, it will be written. this PR just minifies the cache to ensure it is the same.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Unit tests
