### PR TITLE
[AZINTS] fix generate uid

### DIFF
--- a/control_plane/tasks/common.py
+++ b/control_plane/tasks/common.py
@@ -48,7 +48,7 @@ def generate_unique_id() -> str:
     >>> generate_unique_id()
     "c5653797a664"
     """
-    return str(uuid4())[:12]
+    return str(uuid4())[-12:]
 
 
 async def collect(it: AsyncIterable[T]) -> list[T]:

--- a/control_plane/tasks/tests/test_common.py
+++ b/control_plane/tasks/tests/test_common.py
@@ -9,7 +9,7 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.core.polling import AsyncLROPoller
 
 # project
-from tasks.common import average, now, wait_for_resource
+from tasks.common import average, generate_unique_id, now, wait_for_resource
 
 
 class MockPoller(AsyncLROPoller):
@@ -50,3 +50,7 @@ class TestCommon(IsolatedAsyncioTestCase):
     async def test_wait_for_resource_3_tries(self):
         res = await wait_for_resource(MockPoller(), make_check_resource(tries=3))
         self.assertEqual(res, "result")
+
+    def test_generate_unique_id(self):
+        for _ in range(10):  # test multiple times to ensure
+            self.assertRegex(generate_unique_id(), r"[0-9a-f]{12}")


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Made an oopsie:
```py
In [2]: str(uuid4())[-12:]
Out[2]: '13fcd713e03d'

In [3]: str(uuid4())[:12]
Out[3]: '26b1fb57-092'
```

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

added test to not footgun in the future
