### PR TITLE
[azints-2736] publish forwarder container to internal repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,10 +3,10 @@ variables:
   DOCKER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
   CI_IMAGE: registry.ddbuild.io/ci/azure-log-forwarding-orchestration-ci:latest
 stages:
-  - publish
   - ci-image
   - test
   - after-test
+  - publish
 # ------------- CI IMAGE -------------
 ci-build-image:
   image: $DOCKER_IMAGE
@@ -65,13 +65,11 @@ forwarder-publish:
   image: $DOCKER_IMAGE
   stage: publish
   tags: ["arch:amd64"]
-  #  tags: ["runner:docker"]
-  #    image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datastores:$CURRENT_CI_IMAGE
   script:
     - ci/scripts/forwarder/publish.sh
-#    only:
-#      refs:
-#        - master
+  only:
+    refs:
+      - main
 # ------------- CODE COV -------------
 forwarder-coverage-comment:
   image: $PR_COMMENTER_IMAGE

--- a/ci/scripts/forwarder/publish.sh
+++ b/ci/scripts/forwarder/publish.sh
@@ -4,10 +4,4 @@ set -euxo pipefail
 
 cd forwarder
 
-#docker build --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/lfo/forwarder:latest .
-#docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/lfo/forwarder:latest
-#docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/lfo/forwarder:latest registry.ddbuild.io/lfo/forwarder:latest
-
-docker buildx build --platform=linux/amd64 --label target=build --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/lfo/forwarder:latest --push .
-
 docker buildx build --platform=linux/amd64 --label target=build --tag registry.ddbuild.io/lfo/forwarder:latest --push .


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-2736](https://datadoghq.atlassian.net/browse/AZINTS-2736)

Publishes images for the forwarder to ddbuild on the main branch

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->


[AZINTS-2736]: https://datadoghq.atlassian.net/browse/AZINTS-2736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ