### PR TITLE
[AZINTS-2724] ensure all azure strings are compared case-insensitively

### DIFF
--- a/control_plane/cache/common.py
+++ b/control_plane/cache/common.py
@@ -39,15 +39,15 @@ def get_container_app_name(config_id: str) -> str:
 
 
 def get_resource_group_id(subscription_id: str, resource_group: str) -> str:
-    return f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+    return f"/subscriptions/{subscription_id}/resourcegroups/{resource_group}".casefold()
 
 
 def get_container_app_id(subscription_id: str, resource_group: str, config_id: str) -> str:
     return (
         get_resource_group_id(subscription_id, resource_group)
-        + "/providers/Microsoft.App/jobs/"
+        + "/providers/microsoft.app/jobs/"
         + get_container_app_name(config_id)
-    )
+    ).casefold()
 
 
 def get_managed_env_name(config_id: str) -> str:
@@ -57,9 +57,9 @@ def get_managed_env_name(config_id: str) -> str:
 def get_managed_env_id(subscription_id: str, resource_group: str, config_id: str) -> str:
     return (
         get_resource_group_id(subscription_id, resource_group)
-        + "/providers/Microsoft.App/managedEnvironments/"
+        + "/providers/microsoft.app/managedenvironments/"
         + get_managed_env_name(config_id)
-    )
+    ).casefold()
 
 
 def get_storage_account_name(config_id: str) -> str:
@@ -69,9 +69,9 @@ def get_storage_account_name(config_id: str) -> str:
 def get_storage_account_id(subscription_id: str, resource_group: str, config_id: str) -> str:
     return (
         get_resource_group_id(subscription_id, resource_group)
-        + "/providers/Microsoft.Storage/storageAccounts/"
+        + "/providers/microsoft.storage/storageaccounts/"
         + get_storage_account_name(config_id)
-    )
+    ).casefold()
 
 
 # TODO We will need to add prefixes for these when we implement event hub support

--- a/control_plane/cache/tests/test_common.py
+++ b/control_plane/cache/tests/test_common.py
@@ -34,27 +34,31 @@ class TestCommon(TestCase):
 
     def test_get_resource_group_id(self):
         self.assertEqual(
-            "/subscriptions/sub1/resourceGroups/rg1",
+            "/subscriptions/sub1/resourcegroups/rg1",
             get_resource_group_id("sub1", "rg1"),
         )
+        self.assertTrue(get_resource_group_id("UpperCaseSub", "SomeUpperCaseRG").islower())
 
     def test_get_container_app_id(self):
         self.assertEqual(
-            "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/jobs/dd-log-forwarder-config1",
+            "/subscriptions/sub1/resourcegroups/rg1/providers/microsoft.app/jobs/dd-log-forwarder-config1",
             get_container_app_id(sub1, rg1, config1),
         )
+        self.assertTrue(get_container_app_id("UpperCaseSub", "SomeUpperCaseRG", config1).islower())
 
     def test_get_managed_env_id(self):
         self.assertEqual(
-            "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/dd-log-forwarder-env-config1",
+            "/subscriptions/sub1/resourcegroups/rg1/providers/microsoft.app/managedenvironments/dd-log-forwarder-env-config1",
             get_managed_env_id(sub1, rg1, config1),
         )
+        self.assertTrue(get_managed_env_id("UpperCaseSub", "SomeUpperCaseRG", config1).islower())
 
     def test_get_storage_account_id(self):
         self.assertEqual(
-            "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/ddlogstorageconfig1",
+            "/subscriptions/sub1/resourcegroups/rg1/providers/microsoft.storage/storageaccounts/ddlogstorageconfig1",
             get_storage_account_id(sub1, rg1, config1),
         )
+        self.assertTrue(get_storage_account_id("UpperCaseSub", "SomeUpperCaseRG", config1).islower())
 
 
 class TestCacheUtils(IsolatedAsyncioTestCase):

--- a/control_plane/tasks/constants.py
+++ b/control_plane/tasks/constants.py
@@ -148,5 +148,5 @@ ALLOWED_TYPES_PER_PROVIDER = {
     "NGINX.NGINXPLUS": {"nginxDeployment"},
 }
 ALLOWED_RESOURCE_TYPES = {
-    f"{rp}/{rt}".lower() for rp, resource_types in ALLOWED_TYPES_PER_PROVIDER.items() for rt in resource_types
+    f"{rp}/{rt}".casefold() for rp, resource_types in ALLOWED_TYPES_PER_PROVIDER.items() for rt in resource_types
 }

--- a/control_plane/tasks/resources_task.py
+++ b/control_plane/tasks/resources_task.py
@@ -39,7 +39,7 @@ class ResourcesTask(Task):
         async with SubscriptionClient(self.credential) as subscription_client:
             await gather(
                 *[
-                    self.process_subscription(cast(str, sub.subscription_id))
+                    self.process_subscription(cast(str, sub.subscription_id).casefold())
                     async for sub in subscription_client.subscriptions.list()
                 ]
             )
@@ -50,11 +50,11 @@ class ResourcesTask(Task):
             resources_per_region: dict[str, set[str]] = {}
             resource_count = 0
             async for r in client.resources.list():
-                region = cast(str, r.location).lower()
-                resource_type = cast(str, r.type).lower()
+                region = cast(str, r.location).casefold()
+                resource_type = cast(str, r.type).casefold()
                 if region in DISALLOWED_REGIONS or resource_type not in ALLOWED_RESOURCE_TYPES:
                     continue
-                resources_per_region.setdefault(region, set()).add(cast(str, r.id))
+                resources_per_region.setdefault(region, set()).add(cast(str, r.id).casefold())
                 resource_count += 1
             log.debug("Subscription %s: Collected %s resources", subscription_id, resource_count)
             self.resource_cache[subscription_id] = resources_per_region

--- a/control_plane/tasks/tests/test_diagnostic_settings_task.py
+++ b/control_plane/tasks/tests/test_diagnostic_settings_task.py
@@ -22,7 +22,7 @@ from tasks.tests.common import AzureModelMatcher, TaskTestCase, async_generator,
 sub_id1: Final = "sub1"
 region1: Final = "region1"
 config_id1: Final = "bc666ef914ec"
-resource_id1: Final = "/subscriptions/1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+resource_id1: Final = "/subscriptions/1/resourcegroups/rg1/providers/microsoft.compute/virtualmachines/vm1"
 storage_account1: Final = "/subscriptions/1/resourceGroups/lfo/providers/Microsoft.Storage/storageAccounts/storageacc1"
 
 
@@ -79,7 +79,7 @@ class TestDiagnosticSettingsTask(TaskTestCase):
             AzureModelMatcher(
                 {
                     "logs": [{"category": "cool_logs", "enabled": True}],
-                    "storage_account_id": "/subscriptions/sub1/resourceGroups/lfo/providers/Microsoft.Storage/storageAccounts/ddlogstoragebc666ef914ec",
+                    "storage_account_id": "/subscriptions/sub1/resourcegroups/lfo/providers/microsoft.storage/storageaccounts/ddlogstoragebc666ef914ec",
                 }
             ),
         )
@@ -130,7 +130,7 @@ class TestDiagnosticSettingsTask(TaskTestCase):
             AzureModelMatcher(
                 {
                     "logs": [{"category": "cool_logs", "enabled": True}],
-                    "storage_account_id": "/subscriptions/sub1/resourceGroups/lfo/providers/Microsoft.Storage/storageAccounts/ddlogstoragebc666ef914ec",
+                    "storage_account_id": "/subscriptions/sub1/resourcegroups/lfo/providers/microsoft.storage/storageaccounts/ddlogstoragebc666ef914ec",
                 }
             ),
         )
@@ -163,7 +163,7 @@ class TestDiagnosticSettingsTask(TaskTestCase):
             AzureModelMatcher(
                 {
                     "logs": [{"category": "cool_logs", "enabled": True}],
-                    "storage_account_id": "/subscriptions/sub1/resourceGroups/lfo/providers/Microsoft.Storage/storageAccounts/ddlogstoragebc666ef914ec",
+                    "storage_account_id": "/subscriptions/sub1/resourcegroups/lfo/providers/microsoft.storage/storageaccounts/ddlogstoragebc666ef914ec",
                 }
             ),
         )


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-2724

Ensure we are using `.casefold()` for comparing all strings provided by azure (which we know may not be lower case ascii). We opt for `casefold` over `lower`, as while they function mostly the same, there are some edge cases in non-english languages that `casefold` will help to properly compare against that `lower` wont.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Tested in the portal and with existing unit tests.

Added additional unit tests to ensure we don't regress.