### PR TITLE
[Forwarder] add site configuration

### DIFF
--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -242,6 +242,8 @@ func main() {
 	var err error
 	span, ctx := tracer.StartSpanFromContext(context.Background(), "forwarder.main")
 	defer span.Finish(tracer.WithError(err))
+
+	// Set Datadog API Key
 	ctx = context.WithValue(
 		ctx,
 		datadog.ContextAPIKeys,
@@ -251,6 +253,18 @@ func main() {
 			},
 		},
 	)
+
+	// Set Datadog site
+	ddSite := os.Getenv("DD_SITE")
+	if ddSite == "" {
+		ddSite = "datadoghq.com"
+	}
+	ctx = context.WithValue(ctx,
+		datadog.ContextServerVariables,
+		map[string]string{
+			"site": ddSite,
+		})
+
 	start := time.Now()
 	log.SetFormatter(&log.JSONFormatter{})
 	logger := log.WithFields(log.Fields{"service": "forwarder"})


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-2528](https://datadoghq.atlassian.net/browse/AZINTS-2528)

Adds site configuration for the forwarder following our [documentation](https://datadoghq.atlassian.net/browse/AZINTS-2528) 

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Correctly forwards to us3 with the DD_SITE env set to us3.datadoghq.com. See the request variable in the debugging session
<img width="1310" alt="Screenshot 2024-09-24 at 7 04 55 PM" src="https://github.com/user-attachments/assets/dffbe1a9-6afa-4555-8402-000b49027bd4">



[AZINTS-2528]: https://datadoghq.atlassian.net/browse/AZINTS-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ