### PR TITLE
[AZINTS] dont need dependencies for publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,9 +48,6 @@ build-and-publish-tasks:
   image: $CI_IMAGE
   stage: after-test
   tags: ["arch:amd64"]
-  dependencies:
-    - forwarder-tests
-    - control-plane-tests
   variables:
     KUBERNETES_POD_ANNOTATIONS_azure: cloud-iam.emissary.datadoghq.com/azure=88d13348-0530-418a-89c0-9caa32d59037
   script:


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

We don't need these for publishing, they are only needed in the coverage comment job because of the coverage artifacts. We build from scratch so should be fine.

When tests fail, the whole after-test section is skipped. Unless a job is marked as "allowed to fail", it will exit the pipeline early.
<img width="973" alt="image" src="https://github.com/user-attachments/assets/0fa58766-2e82-4859-9e04-1f436bed2da0">


## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

CI