### PR TITLE
[AZINTS-2761] fix deploy url

### DIFF
--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -258,7 +258,7 @@ class DeployerTask(Task):
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
     async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:
         resp = await self.rest_client.post(
-            f"https://{function_app_name}.scm.azurewebsites.net/api/publish?type=zip",
+            f"https://{function_app_name}.scm.azurewebsites.net/api/zipdeploy",
             data=function_app_data,
         )
         if not resp.ok:


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira: [AZINTS-2761](https://datadoghq.atlassian.net/browse/AZINTS-2761)

Points to the correct deploy url

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

it works [in the portal](https://portal.azure.com/#@devdatadoghq.onmicrosoft.com/resource/subscriptions/0b62a232-b8db-4380-9da6-640f7272ed6d/resourceGroups/datadog-log-forwarding/overview) 🥹

[AZINTS-2803]: https://datadoghq.atlassian.net/browse/AZINTS-2803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AZINTS-2761]: https://datadoghq.atlassian.net/browse/AZINTS-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ