### PR TITLE
[AZINTS] consolidate pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,7 @@ forwarder-publish:
 # ------------- CODE COV -------------
 coverage-comment:
   image: $PR_COMMENTER_IMAGE
-  stage: test
+  stage: build
   tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH != "main"


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

makes things run faster/in parallel.

splits out build from publish, and makes the publishing tasks job manual
