### PR TITLE
[AZINTS] speed up mypy and make it strict

### DIFF
--- a/control_plane/cache/common.py
+++ b/control_plane/cache/common.py
@@ -6,7 +6,7 @@ from typing import Any, Final, Literal, NamedTuple, TypeVar
 
 # 3p
 from azure.core.exceptions import ResourceNotFoundError
-from azure.storage.blob.aio import BlobClient
+from azure.storage.blob.aio import BlobClient, StorageStreamDownloader
 from jsonschema import ValidationError, validate
 
 BLOB_STORAGE_CACHE = "control-plane-cache"
@@ -80,11 +80,11 @@ EVENT_HUB_NAMESPACE_PREFIX = NotImplemented
 
 
 def get_event_hub_name(config_id: str) -> str:  # pragma: no cover
-    return EVENT_HUB_NAME_PREFIX + config_id
+    return EVENT_HUB_NAME_PREFIX + config_id  # type: ignore
 
 
 def get_event_hub_namespace(config_id: str) -> str:  # pragma: no cover
-    return EVENT_HUB_NAMESPACE_PREFIX + config_id
+    return EVENT_HUB_NAMESPACE_PREFIX + config_id  # type: ignore
 
 
 LogForwarderType = Literal["eventhub", "storageaccount"]
@@ -111,7 +111,7 @@ async def read_cache(blob_name: str) -> str:
         get_config_option(STORAGE_CONNECTION_SETTING), BLOB_STORAGE_CACHE, blob_name
     ) as blob_client:
         try:
-            blob = await blob_client.download_blob()
+            blob: StorageStreamDownloader[bytes] = await blob_client.download_blob()
         except ResourceNotFoundError:
             return ""
         return (await blob.readall()).decode()

--- a/control_plane/pyproject.toml
+++ b/control_plane/pyproject.toml
@@ -69,5 +69,18 @@ indent-style = "space"
 docstring-code-format = true
 
 [tool.mypy]
+strict = true
 check_untyped_defs = true
-ignore_missing_imports = true
+disable_error_code = [
+    "import-untyped",
+    "unused-ignore",   # used for incompatibilities with pyright and mypy
+    "no-untyped-call", # datadog api library problems
+]
+# exclude test files and config directory
+exclude = ".*test.*|config/"
+
+
+[[tool.mypy.overrides]]
+module = "azure.mgmt.*"
+# azure mgmt modules are very slow and we do not have control, we should skip those
+follow_imports = "skip"

--- a/control_plane/tasks/common.py
+++ b/control_plane/tasks/common.py
@@ -44,7 +44,7 @@ def chunks(lst: list[T], n: int) -> Iterable[tuple[T, ...]]:
     return zip(*(lst[i::n] for i in range(n)), strict=False)
 
 
-def log_errors(message: str, *maybe_errors: object | Exception, reraise=False) -> list[Exception]:
+def log_errors(message: str, *maybe_errors: object | Exception, reraise: bool = False) -> list[Exception]:
     """Log and return any errors in `maybe_errors`.
     If reraise is True, the first error will be raised"""
     errors = [e for e in maybe_errors if isinstance(e, Exception)]

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -278,7 +278,7 @@ class DeployerTask(Task):
         await write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache))
 
 
-async def main():
+async def main() -> None:
     async with DeployerTask() as deployer:
         await deployer.run()
 

--- a/control_plane/tasks/diagnostic_settings_task.py
+++ b/control_plane/tasks/diagnostic_settings_task.py
@@ -210,7 +210,7 @@ class DiagnosticSettingsTask(Task):
         pass  # nothing to do here
 
 
-async def main():
+async def main() -> None:
     basicConfig(level=INFO)
     log.info("Started task at %s", now())
     assignment_cache = await read_cache(ASSIGNMENT_CACHE_BLOB)

--- a/control_plane/tasks/task.py
+++ b/control_plane/tasks/task.py
@@ -14,7 +14,7 @@ log = getLogger(__name__)
 getLogger("azure").setLevel(ERROR)
 
 
-class Task(AbstractAsyncContextManager):
+class Task(AbstractAsyncContextManager["Task"]):
     def __init__(self) -> None:
         self.credential = DefaultAzureCredential()
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

We should skip mgmt libraries, theyre like 30k lines each and majorly slow down mypy, even when we have no control.

Doing this also lets us upgrade to strict mypy typing which will allow us to be more confident in our types.

Also helped us catch a bug that I didnt notice before (in the scaling task)

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

CI

speeds up the job from roughly [4 minutes](https://gitlab.ddbuild.io/DataDog/azure-log-forwarding-orchestration/-/jobs/668997188) to [1 minute](https://gitlab.ddbuild.io/DataDog/azure-log-forwarding-orchestration/-/jobs/668973664) for the job to run.
