### PR TITLE
[AZINTS] make build ci be automated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,9 +91,9 @@ deployer-build-latest:
 deployer-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: manual
+  only:
+    refs:
+      - main
   tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 --tag registry.ddbuild.io/lfo/deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} -f "ci/deployer-task/Dockerfile" ./control_plane --push


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Right now because the build stage is manual, we cant run the publish stage until it completes. lets make it automated since we'll always want to do it anyways

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

CI
