### PR TITLE
[Scaling Task] Fix file deletion policy

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -36,6 +36,7 @@ from azure.mgmt.storage.v2023_05_01.models import (
     ManagementPolicyAction,
     ManagementPolicyBaseBlob,
     ManagementPolicyDefinition,
+    ManagementPolicyFilter,
     ManagementPolicyName,
     ManagementPolicyRule,
     ManagementPolicySchema,
@@ -282,6 +283,9 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
                                             days_after_creation_greater_than=FORWARDER_METRIC_BLOB_LIFETIME_DAYS
                                         )
                                     ),
+                                ),
+                                filters=ManagementPolicyFilter(
+                                    blob_types=["blockBlob", "appendBlob"],
                                 ),
                             ),
                         )

--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -488,6 +488,9 @@ class TestLogForwarderClient(AsyncTestCase):
                                         "base_blob": {"delete": {"days_after_modification_greater_than": 1}},
                                         "snapshot": {"delete": {"days_after_creation_greater_than": 1}},
                                     },
+                                    "filters": {
+                                        "blob_types": ["blockBlob", "appendBlob"],
+                                    },
                                 },
                             }
                         ]


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira Ticket: [AZINTS-2905](https://datadoghq.atlassian.net/browse/AZINTS-2905)

Previously we were seeing errors due to no filter existing. See errors below 
```
ERROR:tasks.common:Failed to create function app and/or get blob forwarder data: [HttpResponseError('(InvalidManagementPolicyRule) ManagementPolicy rule Delete Old Metric Blobs is invalid. Invalid value for parameter : filter is required For more information, see - https://aka.ms/managementpolicyexamples\nCode: InvalidManagementPolicyRule\nMessage: ManagementPolicy rule Delete Old Metric Blobs is invalid. Invalid value for parameter : filter is required For more information, see - https://aka.ms/managementpolicyexamples')]
```

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->
executed the scaling task

[AZINTS-2905]: https://datadoghq.atlassian.net/browse/AZINTS-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ