### PR TITLE
[AZINTS] apply bash linting fixes and clean up ci scripts

### DIFF
--- a/ci/scripts/control_plane/build_tasks.sh
+++ b/ci/scripts/control_plane/build_tasks.sh
@@ -12,33 +12,33 @@ cd ./control_plane
 pip install '.[dev]'
 
 tasks="$(python -m tasks)"
-echo Building the following tasks: $tasks
+echo Building the following tasks: "$tasks"
 cd ..
 for task in $tasks; do
     echo "Building $task"
-    mkdir -p ./dist/$task/$task
+    mkdir -p "./dist/$task/$task"
 
-    : Compile $task into a single file
-    stickytape ./control_plane/tasks/$task.py \
+    : Compile "$task" into a single file
+    stickytape "./control_plane/tasks/$task.py" \
         --add-python-path ./control_plane \
-        --output-file ./dist/$task/$task/task.py
+        --output-file "./dist/$task/$task/task.py"
 
     : requirements.txt
     python -c "import tomllib; project = tomllib.load(open('./control_plane/pyproject.toml','rb'))['project']; print('\n'.join(project['dependencies'] + project['optional-dependencies']['$task']))" \
-        > ./dist/$task/requirements.txt
+        > "./dist/$task/requirements.txt"
 
     : entrypoint
-    cp ./control_plane/config/__init__.py ./dist/$task/$task/__init__.py
+    cp ./control_plane/config/__init__.py "./dist/$task/$task/__init__.py"
 
     : function.json
-    cp ./control_plane/config/$task/function.json ./dist/$task/$task/function.json
+    cp "./control_plane/config/$task/function.json" "./dist/$task/$task/function.json"
 
     : host.json
-    cp ./control_plane/config/host.json ./dist/$task/host.json
+    cp "./control_plane/config/host.json" "./dist/$task/host.json"
 
     : zip it up for zipdeploy
-    cd ./dist/$task
-    zip -r ../$task.zip *
+    cd "./dist/$task"
+    zip -r "../$task.zip" ./*
     cd -
     echo "Built $task"
 done

--- a/ci/scripts/control_plane/format.sh
+++ b/ci/scripts/control_plane/format.sh
@@ -6,8 +6,5 @@ set -euxo pipefail
 
 cd control_plane
 
-: make sure all deps are installed
-pip install -e '.[dev]'
-
 : run ruff format
 ruff format --check

--- a/ci/scripts/control_plane/lint.sh
+++ b/ci/scripts/control_plane/lint.sh
@@ -6,8 +6,5 @@ set -euxo pipefail
 
 cd control_plane
 
-: make sure all deps are installed
-pip install -e '.[dev]'
-
 : run linter
 ruff check

--- a/ci/scripts/control_plane/type-check.sh
+++ b/ci/scripts/control_plane/type-check.sh
@@ -2,7 +2,7 @@
 
 source /venv/bin/activate
 
-set -uxo pipefail
+set -euxo pipefail
 
 cd control_plane
 

--- a/ci/scripts/coverage-comment.sh
+++ b/ci/scripts/coverage-comment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -uxo pipefail
 
 curl -f -v 'https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment'\
     -H "$(/bin/authanywhere)"\

--- a/ci/scripts/forwarder/build_and_push.sh
+++ b/ci/scripts/forwarder/build_and_push.sh
@@ -4,4 +4,4 @@ set -euxo pipefail
 
 cd forwarder
 
-docker buildx build --platform=linux/amd64 --label target=build --tag $1/forwarder:$2 --push .
+docker buildx build --platform=linux/amd64 --label target=build --tag "$1/forwarder:$2" --push .


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Applies some bash linting fixes and makes the correct change that wasnt done properly here: https://github.com/DataDog/azure-log-forwarding-orchestration/pull/140 (ensuring that the commenter doesnt hard fail, previously it just made type check not use strict mode, and the commenter would still be able to fail).

Also makes the `ruff` CI steps not ensure every dependency is installed, since linting and formatting don't require project dependencies.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Testing on this PR that CI should still pass as expected.