### PR TITLE
[AZINTS-2934] lengthen the scaling task timeout

### DIFF
--- a/control_plane/config/scaling_task/function.json
+++ b/control_plane/config/scaling_task/function.json
@@ -7,7 +7,7 @@
             "type": "timerTrigger",
             "direction": "in",
             "schedule": "0 */5 * * * *",
-            "functionTimeout": "00:30:00"
+            "functionTimeout": "00:10:00"
         }
     ]
 }


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-2934](https://datadoghq.atlassian.net/browse/AZINTS-2934)

Default timeout is the period of the schedule, overrides the timeout to 30mins
## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->


[AZINTS-2934]: https://datadoghq.atlassian.net/browse/AZINTS-2934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ