### PR TITLE
[LFO] Add config_id and control_plane_id tags to forwarder logs

### DIFF
--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -274,13 +274,13 @@ func main() {
 		datadog.ContextAPIKeys,
 		map[string]datadog.APIKey{
 			"apiKeyAuth": {
-				Key: environment.GetEnvVar(environment.DD_API_KEY),
+				Key: environment.Get(environment.DD_API_KEY),
 			},
 		},
 	)
 
 	// Set Datadog site
-	ddSite := environment.GetEnvVar(environment.DD_SITE)
+	ddSite := environment.Get(environment.DD_SITE)
 	if ddSite == "" {
 		ddSite = "datadoghq.com"
 	}
@@ -303,7 +303,7 @@ func main() {
 				profiler.MutexProfile,
 				profiler.GoroutineProfile,
 			),
-			profiler.WithAPIKey(environment.GetEnvVar(environment.DD_API_KEY)),
+			profiler.WithAPIKey(environment.Get(environment.DD_API_KEY)),
 			profiler.WithService(serviceName),
 			profiler.WithAgentlessUpload(),
 		)
@@ -315,13 +315,13 @@ func main() {
 
 	logger.Info(fmt.Sprintf("Start time: %v", start.String()))
 
-	forceProfile := environment.GetEnvVar(environment.DD_FORCE_PROFILE)
+	forceProfile := environment.Get(environment.DD_FORCE_PROFILE)
 	if forceProfile != "" {
 		// Sleep for 5 seconds to allow profiler to start
 		time.Sleep(5 * time.Second)
 	}
 
-	goroutineString := environment.GetEnvVar(environment.NUM_GOROUTINES)
+	goroutineString := environment.Get(environment.NUM_GOROUTINES)
 	if goroutineString == "" {
 		goroutineString = "10"
 	}
@@ -331,7 +331,7 @@ func main() {
 	}
 
 	// Initialize storage client
-	storageAccountConnectionString := environment.GetEnvVar(environment.AZURE_WEB_JOBS_STORAGE)
+	storageAccountConnectionString := environment.Get(environment.AZURE_WEB_JOBS_STORAGE)
 	azBlobClient, err := azblob.NewClientFromConnectionString(storageAccountConnectionString, nil)
 	if err != nil {
 		logger.Fatalf(fmt.Errorf("error creating azure blob client: %w", err).Error())

--- a/forwarder/internal/environment/variables.go
+++ b/forwarder/internal/environment/variables.go
@@ -16,12 +16,12 @@ const (
 	NUM_GOROUTINES         = "NUM_GOROUTINES"
 )
 
-func GetEnvVar(varName string) string {
-	return os.Getenv(varName)
+func Get(envVar string) string {
+	return os.Getenv(envVar)
 }
 
 func Enabled(environmentVariable string) bool {
-	return GetEnvVar(environmentVariable) == "true"
+	return Get(environmentVariable) == "true"
 }
 
 func APMEnabled() bool {

--- a/forwarder/internal/environment/variables_test.go
+++ b/forwarder/internal/environment/variables_test.go
@@ -69,7 +69,7 @@ func TestGetEnv(t *testing.T) {
 		require.NoError(t, err)
 
 		// WHEN
-		envVarValue := environment.GetEnvVar(testKey)
+		envVarValue := environment.Get(testKey)
 
 		// THEN
 		assert.Equal(t, envVarValue, testValue, "values should be equal")
@@ -80,7 +80,7 @@ func TestGetEnv(t *testing.T) {
 		testKey := uuid.New().String()
 
 		// WHEN
-		envVarValue := environment.GetEnvVar(testKey)
+		envVarValue := environment.Get(testKey)
 
 		// THEN
 		assert.Equal(t, "", envVarValue, "envVarValue should be empty string")

--- a/forwarder/internal/logs/logs.go
+++ b/forwarder/internal/logs/logs.go
@@ -72,12 +72,12 @@ func NewLog(blob storage.Blob, logBytes []byte) (*Log, error) {
 
 func getTags(id *arm.ResourceID) []string {
 	return []string{
-		"subscription_id:" + id.SubscriptionID,
-		"resource_group:" + id.ResourceGroupName,
-		"source:" + strings.Replace(id.ResourceType.String(), "/", ".", -1),
-		"forwarder:lfo",
-		"control_plane_id:" + environment.GetEnvVar(environment.CONTROL_PLANE_ID),
-		"config_id:" + environment.GetEnvVar(environment.CONFIG_ID),
+		fmt.Sprintf("subscription_id:%s", id.SubscriptionID),
+		fmt.Sprintf("resource_group:%s", id.ResourceGroupName),
+		fmt.Sprintf("source:%s", strings.Replace(id.ResourceType.String(), "/", ".", -1)),
+		fmt.Sprintf("forwarder:%s", "lfo"),
+		fmt.Sprintf("control_plane_id:%s", environment.Get(environment.CONTROL_PLANE_ID)),
+		fmt.Sprintf("config_id:%s", environment.Get(environment.CONFIG_ID)),
 	}
 }
 


### PR DESCRIPTION
## Description
- Added config_id and control_plane_id to included tags on forwarder logs
- Centralized forwarder environment vars in `variables.go`

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-2903

## Testing
Manually tested
<img width="680" alt="image" src="https://github.com/user-attachments/assets/bd0b2f58-9b9c-4f75-b03b-6b768764310f">

