### PR TITLE
[LFO] CI step for go fmt

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,7 @@ forwarder-vet:
     - go vet ./...
 forwarder-format:
   image: $CI_IMAGE
-  stage: ci-image
+  stage: test
   tags: ["arch:amd64"]
   script:
     - cd forwarder

--- a/forwarder/internal/logs/logs.go
+++ b/forwarder/internal/logs/logs.go
@@ -43,14 +43,6 @@ const functionAppContainer = "insights-logs-functionapplogs"
 
 // Log represents a log to send to Datadog.
 type Log struct {
-
-
-
-//yayayayayayay
-
-
-
-
 	content    *[]byte
 	ByteSize   int64
 	Tags       []string


### PR DESCRIPTION
## Description
- Introduce [`go fmt`](https://pkg.go.dev/cmd/gofmt) verification to forwarder ci steps. 

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-2804

## Testing
Manual testing.

Green run: https://gitlab.ddbuild.io/DataDog/azure-log-forwarding-orchestration/-/pipelines/49680417
<img width="914" alt="image" src="https://github.com/user-attachments/assets/33d10fe7-a05e-4468-b7f0-3c23db798fc2">



Issue flagged and job failed when I manually stuck extra whitespace in a file:
https://gitlab.ddbuild.io/DataDog/azure-log-forwarding-orchestration/-/pipelines/49680093
![image](https://github.com/user-attachments/assets/93f9b5b0-02c5-418b-8f58-d830740ae246)
![image](https://github.com/user-attachments/assets/b2126203-7388-408b-828c-f722e681c8c6)

