### PR TITLE
[bicep] parameterize storage account in deployment

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -13,6 +13,7 @@ param datadogApiKey string
 param datadogSite string
 
 param imageRegistry string = 'datadoghq.azurecr.io'
+param storageAccountUrl string = 'https://ddazurelfo.blob.core.windows.net'
 
 module controlPlaneSubscription './subscription.bicep' = {
   name: 'createControlPlaneResourceGroup'
@@ -48,6 +49,7 @@ module controlPlaneResourceGroup './control_plane.bicep' = {
     datadogApplicationKey: datadogApplicationKey
     datadogSite: datadogSite
     imageRegistry: imageRegistry
+    storageAccountUrl: storageAccountUrl
   }
   dependsOn: [
     controlPlaneSubscription

--- a/deploy/control_plane.bicep
+++ b/deploy/control_plane.bicep
@@ -9,6 +9,7 @@ param controlPlaneResourceGroupName string
 param monitoredSubscriptions string
 
 param imageRegistry string
+param storageAccountUrl string
 
 @description('Datadog API Key')
 @secure()
@@ -194,6 +195,7 @@ resource deployerTask 'Microsoft.App/jobs@2024-03-01' = {
             { name: 'DD_API_KEY', secretRef: 'dd-api-key' }
             { name: 'DD_APP_KEY', secretRef: 'dd-app-key' }
             { name: 'DD_SITE', value: datadogSite }
+            { name: 'STORAGE_ACCOUNT_URL', value: storageAccountUrl }
           ]
         }
       ]


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Parameterizes storage account in deployment for the deployer task. This will allow us to more effectively use QA, staging and per branch environments. 

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->
Verified we could still deploy via `az deployment mg create`