### PR TITLE
[LFO] Move ARM template upload CI tasks under publish stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,7 +97,7 @@ publish-tasks-qa:
     - build-tasks
 arm-template-publish-qa:
   image: $CI_IMAGE
-  stage: ci-image
+  stage: publish
   tags: ["arch:amd64"]
   only:
     refs:
@@ -108,7 +108,7 @@ arm-template-publish-qa:
     - ./ci/scripts/arm-template/upload-qa-env.sh
 arm-template-publish:
   image: $CI_IMAGE
-  stage: ci-image
+  stage: publish
   tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"


### PR DESCRIPTION
## Description
I forgot to do this as a last step in [this PR](https://github.com/DataDog/azure-log-forwarding-orchestration/pull/198)

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-2942

## Testing
Testing already done in above PR. 
