### PR TITLE
[bicep] consistent more unique name for control plane deployment

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -15,7 +15,7 @@ param datadogSite string
 param imageRegistry string = 'datadoghq.azurecr.io'
 
 module controlPlaneSubscription './subscription.bicep' = {
-  name: 'createControlPlaneResourceGroup'
+  name: controlPlaneResourceGroupName
   scope: subscription(controlPlaneSubscriptionId)
   params: {
     controlPlaneResourceGroup: controlPlaneResourceGroupName


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->
Uses the control plane resource group name as the deployment name for the control plane. Allows for more deployments of LFO within a subscription.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->
Used the `az deploy` command
