### PR TITLE
[AZINTS] close resources client

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -157,6 +157,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
         self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         await gather(
+            self.resource_client.__aexit__(exc_type, exc_val, exc_tb),
             self.container_apps_client.__aexit__(exc_type, exc_val, exc_tb),
             self.storage_client.__aexit__(exc_type, exc_val, exc_tb),
             self._datadog_client.__aexit__(exc_type, exc_val, exc_tb),


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Noticed in the logs we weren't closing a client:
```
Unclosed client session client_session: <aiohttp.client.ClientSession object at 0x7fe9e66ff690>
```

This should fix that.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Tested by running locally
