### PR TITLE
[AZINTS-2813] trigger deployer task in the template

### DIFF
--- a/deploy/control_plane.bicep
+++ b/deploy/control_plane.bicep
@@ -225,7 +225,7 @@ output scalingTaskPrincipalId string = scalingTask.identity.principalId
 // DEPLOYER TASK INITIAL RUN
 
 resource runInitialDeployIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: 'runInitialDeployIdentity-${controlPlaneId}'
+  name: 'runInitialDeployIdentity'
   location: controlPlaneLocation
 }
 
@@ -241,7 +241,7 @@ resource containerAppStartRole 'Microsoft.Authorization/roleDefinitions@2022-04-
 }
 
 resource runInitialDeployIdentityRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid('runInitialDeployIdentityRoleAssignment', controlPlaneId)
+  name: guid('runInitialDeployIdentityRoleAssignment', controlPlaneResourceGroupName)
   properties: {
     roleDefinitionId: containerAppStartRole.id
     principalId: runInitialDeployIdentity.properties.principalId


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-2813](https://datadoghq.atlassian.net/browse/AZINTS-2813)

Adds a deployment script to trigger the container app job, once the role assignment has completed.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Tested in azure:

During deploy, we see the deployment script (renamed here):
<img width="230" alt="image" src="https://github.com/user-attachments/assets/1c6c8d46-5079-4d50-847c-acbaa520d6c3" />

(the deployment script will be cleaned up automatically)

And then when we check executions:
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/4b7d6a08-9c2b-4394-b37a-6c6b23acb46a" />





[AZINTS-2813]: https://datadoghq.atlassian.net/browse/AZINTS-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ