### PR TITLE
[AZINTS-2813] deploy personal env: remove manual trigger on deploy, simplify later deploys

### DIFF
--- a/scripts/deploy_personal_env.py
+++ b/scripts/deploy_personal_env.py
@@ -228,11 +228,14 @@ else:
             None,
         )
     ):
-        print("Deployer not found, exiting...")
+        print(
+            "Deployer not found, try re-running the script with `--force-arm-deploy` to ensure all resources are created"
+        )
         raise SystemExit(1)
 
-    print(f"\nDeployer Ready, Executing deployer for job {deployer_job}...")
     run(
-        f"az containerapp job start --resource-group {resource_group_name} --name {deployer_job}",
+        f"az containerapp job start --resource-group {resource_group_name} --name {deployer_job}"
     )
-    print(f"Deployer executed for job {deployer_job}")
+    print(
+        f"Deployer job {deployer_job} executed! In a minute or two, all tasks will be redeployed."
+    )


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-2813](https://datadoghq.atlassian.net/browse/AZINTS-2813)

cleans up the deploy script, on initial deploy it will automatically be triggered, which means subsequent deploys can always just use the existing deployer and we can simplify the code

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Manually running the deploy script

[AZINTS-2813]: https://datadoghq.atlassian.net/browse/AZINTS-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ