### PR TITLE
[AZINTS] add descriptions to role assignments

### DIFF
--- a/deploy/control_plane.bicep
+++ b/deploy/control_plane.bicep
@@ -213,7 +213,7 @@ resource deployerTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' =
   name: guid('deployer', controlPlaneId)
   scope: resourceGroup()
   properties: {
-    description: 'lfo${controlPlaneId}'
+    description: 'ddlfo${controlPlaneId}'
     roleDefinitionId: websiteContributorRole.id
     principalId: deployerTask.identity.principalId
   }
@@ -244,7 +244,7 @@ resource containerAppStartRole 'Microsoft.Authorization/roleDefinitions@2022-04-
 resource runInitialDeployIdentityRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid('runInitialDeployIdentityRoleAssignment', controlPlaneResourceGroupName)
   properties: {
-    description: 'lfo${controlPlaneId}'
+    description: 'ddlfo${controlPlaneId}'
     roleDefinitionId: containerAppStartRole.id
     principalId: runInitialDeployIdentity.properties.principalId
     principalType: 'ServicePrincipal'

--- a/deploy/resource_group_permissions.bicep
+++ b/deploy/resource_group_permissions.bicep
@@ -20,7 +20,7 @@ resource diagnosticSettingsTaskStorageRole 'Microsoft.Authorization/roleAssignme
   name: guid(subscription().id, 'storage', 'diagnosticSettings', controlPlaneId)
   scope: resourceGroup()
   properties: {
-    description: 'lfo${controlPlaneId}'
+    description: 'ddlfo${controlPlaneId}'
     roleDefinitionId: readerAndDataAccessRole.id
     principalId: diagnosticSettingsTaskPrincipalId
   }
@@ -30,7 +30,7 @@ resource scalingTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
   name: guid(subscription().id, 'scaling', controlPlaneId)
   scope: resourceGroup()
   properties: {
-    description: 'lfo${controlPlaneId}'
+    description: 'ddlfo${controlPlaneId}'
     roleDefinitionId: contributorRole.id
     principalId: scalingTaskPrincipalId
   }

--- a/deploy/subscription_permissions.bicep
+++ b/deploy/subscription_permissions.bicep
@@ -38,7 +38,7 @@ resource monitoringContributorRole 'Microsoft.Authorization/roleDefinitions@2022
 resource resourceTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, 'resourceTask', controlPlaneId)
   properties: {
-    description: 'lfo${controlPlaneId}'
+    description: 'ddlfo${controlPlaneId}'
     roleDefinitionId: monitoringReaderRole.id
     principalId: resourceTaskPrincipalId
   }
@@ -47,7 +47,7 @@ resource resourceTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' =
 resource diagnosticSettingsTaskMonitorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, 'monitor', 'diagnosticSettings', controlPlaneId)
   properties: {
-    description: 'lfo${controlPlaneId}'
+    description: 'ddlfo${controlPlaneId}'
     roleDefinitionId: monitoringContributorRole.id
     principalId: diagnosticSettingsTaskPrincipalId
   }


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Useful to be able to query role assignments for

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

ran the arm template again and found all the role assignments with `az role assignment list`, which includes the description:
```json
{
  "condition": null,
  "conditionVersion": null,
  "createdBy": "5d1aa0c9-69bb-4617-b025-915ad02ac8b8",
  "createdOn": "2025-01-06T20:08:51.079795+00:00",
  "delegatedManagedIdentityResourceId": null,
  "description": "ddlfo802fd2729107",
  "id": "/subscriptions/0b62a232-b8db-4380-9da6-640f7272ed6d/providers/Microsoft.Authorization/roleAssignments/53417665-6797-50e7-8aad-d6fe2f47a5d7",
  "name": "53417665-6797-50e7-8aad-d6fe2f47a5d7",
  "principalId": "63761c1f-9f79-40a7-8eef-b0270f16ae9e",
  "principalName": "9ff8e8f9-9c0a-41df-ab36-97fc561583c6",
  "principalType": "ServicePrincipal",
  "roleDefinitionId": "/subscriptions/0b62a232-b8db-4380-9da6-640f7272ed6d/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
  "roleDefinitionName": "Monitoring Contributor",
  "scope": "/subscriptions/0b62a232-b8db-4380-9da6-640f7272ed6d",
  "type": "Microsoft.Authorization/roleAssignments",
  "updatedBy": "5d1aa0c9-69bb-4617-b025-915ad02ac8b8",
  "updatedOn": "2025-01-06T21:27:55.190032+00:00"
}
```