### PR TITLE
[AZINTS] fix role name duplication

### DIFF
--- a/deploy/control_plane.bicep
+++ b/deploy/control_plane.bicep
@@ -230,10 +230,12 @@ resource runInitialDeployIdentity 'Microsoft.ManagedIdentity/userAssignedIdentit
   location: controlPlaneLocation
 }
 
+var containerAppStartRoleName = 'ContainerAppStartRole${controlPlaneId}'
+
 resource containerAppStartRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid('containerAppStartRole', controlPlaneId)
+  name: guid(containerAppStartRoleName)
   properties: {
-    roleName: 'ContainerAppStartRole${controlPlaneId}'
+    roleName: containerAppStartRoleName
     description: 'Custom role to start container app jobs'
     type: 'customRole'
     permissions: [{ actions: ['Microsoft.App/jobs/start/action'] }]


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Tried using the root assignable scope, but that is reserved for built in role definitions, so we have to use the resource group. as such, i've opted to make the name and ID fully unique based on the control plane id

We may want to include cleanup of these in our uninstall script


## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

ran in azure: ![image](https://github.com/user-attachments/assets/828a224f-7c9e-4c42-8113-e1b48da539da)
