### PR TITLE
[AZINTS] bump dep versions

### DIFF
--- a/control_plane/pyproject.toml
+++ b/control_plane/pyproject.toml
@@ -17,14 +17,14 @@ resources_task = ["azure-mgmt-resource==23.0.1"]
 diagnostic_settings_task = ["azure-mgmt-monitor==6.0.2"]
 scaling_task = [
     "azure-mgmt-appcontainers==3.1.0",
-    "azure-mgmt-storage==21.2.1",
+    "azure-mgmt-storage==22.0.0",
     "datadog-api-client==2.26.0",
     "aiosonic==0.15.0",                # old version required by datadog-api-client
     "tenacity==9.0.0",
 ]
 deployer_task = [
     "azure-mgmt-web==7.3.0",
-    "azure-mgmt-storage==21.2.1",
+    "azure-mgmt-storage==22.0.0",
     "tenacity==9.0.0",
 ]
 
@@ -35,8 +35,8 @@ dev = [
     "coverage==7.4.4",
     "pycobertura==3.3.2",
     "stickytape==0.2.1",
-    "pyright==1.1.390",
-    "ruff==0.8.2",
+    "pyright==1.1.392.post0",
+    "ruff==0.9.2",
     "types-jsonschema==4.23.0.20240813",
     "types-requests==2.32.0.20240602",
 ]


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Saw in [azure-sdk-rss-feed](https://dd.enterprise.slack.com/archives/C05QVBLDQ06) that theres a new version of one of the libs we use, decided to just bump everything
