### PR TITLE
[AZINTS-3052] fix single max log size

### DIFF
--- a/forwarder/cmd/forwarder/forwarder_test.go
+++ b/forwarder/cmd/forwarder/forwarder_test.go
@@ -329,7 +329,7 @@ func TestProcessLogs(t *testing.T) {
 		// GIVEN
 		oneHundredAs := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		var content string
-		for range logs.MaxPayloadSize / 100 {
+		for range logs.MaxLogSize / 100 {
 			content += oneHundredAs
 		}
 		invalidLog := getLogWithContent(content, 5*time.Minute)

--- a/forwarder/internal/logs/logs.go
+++ b/forwarder/internal/logs/logs.go
@@ -55,7 +55,7 @@ type Log struct {
 
 // Validate checks if the log is valid to send to Datadog.
 func (l *Log) Validate(logger *log.Entry) bool {
-	if l.ByteSize > MaxPayloadSize {
+	if l.ByteSize > MaxLogSize {
 		logger.Warningf("Skipping large log at %s from %s with a size of %d", l.Time.Format(time.RFC3339), l.ResourceId, l.Length())
 		return false
 	}
@@ -238,6 +238,10 @@ const bufferSize = 950
 // MaxPayloadSize is the maximum byte size of the payload to Logs API.
 // https://docs.datadoghq.com/api/latest/logs/
 const MaxPayloadSize = 4 * 1000000
+
+// MaxLogSize is the maximum byte size of a single log to Logs API.
+// https://docs.datadoghq.com/api/latest/logs/
+const MaxLogSize = 1000000
 
 // MaxLogAge is the maximum age a log in the payload to Logs API.
 // https://docs.datadoghq.com/api/latest/logs/

--- a/forwarder/internal/logs/logs_test.go
+++ b/forwarder/internal/logs/logs_test.go
@@ -52,10 +52,10 @@ func TestAddLog(t *testing.T) {
 		var payload []*logs.Log
 		prefix := "{\"category\":\"a\",\"resourceId\":\"/subscriptions/0b62a232-b8db-4380-9da6-640f7272ed6d/resourceGroups/lfo-qa/providers/Microsoft.Web/sites/loggya/appServices\",\"key\":\""
 		suffix := "\"}"
-		targetSize := logs.MaxPayloadSize/2 - len(prefix) - len(suffix) - 3
+		targetSize := logs.MaxLogSize/2 - len(prefix) - len(suffix) - 3
 		logString := fmt.Sprintf("%s%s%s", prefix, strings.Repeat("a", targetSize), suffix)
 		logBytes := []byte(logString)
-		for range 3 {
+		for range 12 {
 			currLog, err := logs.NewLog(logBytes, functionAppContainer)
 			currLog.Time = time.Now().Add(-5 * time.Minute)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-3052

Fixes the max log size to more accurately be 1MB rather than 4MB, which is the payload  size max (with leaving buffer for headers and such)

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Updated tests accordingly
