### PR TITLE
[AZINTS-2897] add grace period when scaling

### DIFF
--- a/control_plane/cache/assignment_cache.py
+++ b/control_plane/cache/assignment_cache.py
@@ -1,5 +1,5 @@
 # stdlib
-from typing import Any, TypeAlias, TypedDict
+from typing import Any, NotRequired, TypeAlias, TypedDict
 
 # 3p
 from jsonschema import ValidationError
@@ -15,6 +15,8 @@ class RegionAssignmentConfiguration(TypedDict, total=True):
     "Mapping of config_id to DiagnosticSettingType"
     resources: dict[str, str]
     "Mapping of resource_id to config_id"
+    on_cooldown: NotRequired[bool]
+    "whether the region has recently scaled up and is on cooldown"
 
 
 AssignmentCache: TypeAlias = dict[str, dict[str, RegionAssignmentConfiguration]]
@@ -36,6 +38,7 @@ ASSIGNMENT_CACHE_SCHEMA: dict[str, Any] = {
                     "type": "object",  # resource_id
                     "additionalProperties": {"type": "string"},  # config_id
                 },
+                "on_cooldown": {"type": "boolean"},
             },
             "required": ["configurations", "resources"],
             "additionalProperties": False,


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-2897

Adds an on_cooldown flag to know when we've just scaled to not try again until later

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Added unit tests. also manually triggered scaling in my personal env to ensure it behaves as expected

Initial run for scaling:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/f4976654-1368-4ef9-8dda-a659ccfbf68c" />
Second run (5 mins later):
<img width="719" alt="image" src="https://github.com/user-attachments/assets/7585fef4-9161-49ff-a7a5-22b0d5eaae16" />
Third run, scaled up again:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/8b5b98b5-9e73-4934-b3eb-a94678c71df7" />
fourth run, on cooldown again:
<img width="708" alt="image" src="https://github.com/user-attachments/assets/52159a87-0964-47e3-ba3b-65d71c7b27e6" />
fifth run, things have calmed down: 
<img width="676" alt="image" src="https://github.com/user-attachments/assets/0708e6df-0788-4056-b6f2-393ee955aff1" />
sixth run was back to normal


