### PR TITLE
[AZINTS] fix bicep deployment region naming collision

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -16,26 +16,6 @@ param imageRegistry string = 'datadoghq.azurecr.io'
 #disable-next-line no-hardcoded-env-urls
 param storageAccountUrl string = 'https://ddazurelfo.blob.core.windows.net'
 
-module controlPlaneResourceGroup './control_plane_resource_group.bicep' = {
-  name: 'controlPlaneResourceGroup'
-  scope: subscription(controlPlaneSubscriptionId)
-  params: {
-    controlPlaneResourceGroup: controlPlaneResourceGroupName
-    controlPlaneLocation: controlPlaneLocation
-  }
-}
-
-module validateAPIKey './validate_key.bicep' = {
-  name: 'validateAPIKey'
-  scope: resourceGroup(controlPlaneSubscriptionId, controlPlaneResourceGroupName)
-  params: {
-    datadogApiKey: datadogApiKey
-    datadogSite: datadogSite
-  }
-  dependsOn: [
-    controlPlaneResourceGroup
-  ]
-}
 
 // sub-uuid for the control plane is based on the identifiers below.
 // This is to be consistent if there are multiple deploys, while still making a unique id.
@@ -49,8 +29,30 @@ var controlPlaneId = toLower(substring(
   12
 ))
 
+module controlPlaneResourceGroup './control_plane_resource_group.bicep' = {
+  name: 'controlPlaneResourceGroup-${controlPlaneId}'
+  scope: subscription(controlPlaneSubscriptionId)
+  params: {
+    controlPlaneResourceGroup: controlPlaneResourceGroupName
+    controlPlaneLocation: controlPlaneLocation
+  }
+}
+
+module validateAPIKey './validate_key.bicep' = {
+  name: 'validateAPIKey-${controlPlaneId}'
+  scope: resourceGroup(controlPlaneSubscriptionId, controlPlaneResourceGroupName)
+  params: {
+    datadogApiKey: datadogApiKey
+    datadogSite: datadogSite
+  }
+  dependsOn: [
+    controlPlaneResourceGroup
+  ]
+}
+
+
 module controlPlane './control_plane.bicep' = {
-  name: 'controlPlane'
+  name: 'controlPlane-${controlPlaneId}'
   scope: resourceGroup(controlPlaneSubscriptionId, controlPlaneResourceGroupName)
   params: {
     controlPlaneId: controlPlaneId

--- a/deploy/subscription_permissions.bicep
+++ b/deploy/subscription_permissions.bicep
@@ -15,7 +15,7 @@ resource forwarderResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' 
 
 // assign the resource group level permissions
 module resourceGroupPermissions './resource_group_permissions.bicep' = {
-  name: 'resourceGroupPermissions'
+  name: 'resourceGroupPermissions-${controlPlaneId}'
   scope: forwarderResourceGroup
   params: {
     controlPlaneId: controlPlaneId


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Saw an issue where creating a deployment in the same subscription but different region would cause an error in validating. This should fix that.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->
