### PR TITLE
[AZINTS] update scaling schedule

### DIFF
--- a/control_plane/config/scaling_task/function.json
+++ b/control_plane/config/scaling_task/function.json
@@ -6,7 +6,7 @@
             "name": "timer",
             "type": "timerTrigger",
             "direction": "in",
-            "schedule": "0 */5 * * * *",
+            "schedule": "30 2/5 * * * *",
             "functionTimeout": "00:10:00"
         }
     ]


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Updates the scaling task schedule to run every 5 minutes but offset 2.5 minutes so we can propagate changes faster on average.

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

Tested in personal env, and saw logs coming in at the 2.5 minute mark instead of the 5

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/V1pjTLXO6A0xXPFWXzr5/8ea7434b-5b73-4ca9-a120-2bd423ae9e81.png)

