### PR TITLE
[AZINTS] mock datadog clients properly

### DIFF
--- a/control_plane/tasks/tests/common.py
+++ b/control_plane/tasks/tests/common.py
@@ -33,6 +33,10 @@ class TaskTestCase(AsyncTestCase):
     def setUp(self) -> None:
         self.credential = self.patch_path("tasks.task.DefaultAzureCredential")
         self.credential.side_effect = AsyncMock
+        self.datadog_api_client = self.patch_path("tasks.task.AsyncApiClient", return_value=AsyncMockClient())
+        self.datadog_logs_api = self.patch_path("tasks.task.LogsApi", return_value=AsyncMock())
+        self.datadog_metrics_api = self.patch_path("tasks.task.MetricsApi", return_value=AsyncMock())
+
         with suppress(AttributeError):
             self.write_cache: AsyncMock = self.patch("write_cache")
 

--- a/control_plane/tasks/tests/test_task.py
+++ b/control_plane/tasks/tests/test_task.py
@@ -1,11 +1,11 @@
 # stdlib
 from logging import INFO, basicConfig
 from unittest import TestCase
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 # project
 from tasks.task import Task, get_error_telemetry
-from tasks.tests.common import AsyncMockClient, TaskTestCase
+from tasks.tests.common import TaskTestCase
 
 
 class TestGetErrorTelemetry(TestCase):
@@ -49,9 +49,6 @@ class TestTask(TaskTestCase):
     async def asyncSetUp(self) -> None:
         await super().asyncSetUp()
         self.cred = self.patch_path("tasks.task.DefaultAzureCredential").return_value
-        self.patch_path("tasks.task.AsyncApiClient", return_value=AsyncMockClient())
-        self.patch_path("tasks.task.LogsApi", return_value=AsyncMock())
-        self.patch_path("tasks.task.MetricsApi", return_value=AsyncMock())
         basicConfig(level=INFO)
 
     @patch.dict("tasks.task.environ", {"DD_TELEMETRY": "false", "DD_API_KEY": "123"}, clear=True)


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

mock it out everywhere so we never hit the apis

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Screenshots/logs of real executions in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?
-->
 - [x] This change is backwards compatible.
