### PR TITLE
[AZINTS-3171] call endpoint to sync triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,9 +58,9 @@ build-tasks:
   image: $CI_IMAGE
   stage: build
   tags: ['arch:amd64']
-  #  only:
-  #    refs:
-  #      - main
+  only:
+    refs:
+      - main
   script:
     - ci/scripts/control_plane/build_tasks.sh
   artifacts:
@@ -72,9 +72,9 @@ publish-tasks:
   image: $CI_IMAGE
   stage: publish
   tags: ['arch:amd64']
-  #  rules:
-  #    - if: $CI_COMMIT_BRANCH == "main"
-  #      when: manual
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: manual
   variables:
     KUBERNETES_POD_ANNOTATIONS_azure: cloud-iam.emissary.datadoghq.com/azure=88d13348-0530-418a-89c0-9caa32d59037
   script:
@@ -85,9 +85,9 @@ publish-tasks-qa:
   image: $CI_IMAGE
   stage: publish
   tags: ['arch:amd64']
-  #  only:
-  #    refs:
-  #      - main
+  only:
+    refs:
+      - main
   script:
     - export AZURE_TENANT_ID=$(vault kv get -field=azureTenantId kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
     - export AZURE_CLIENT_ID=$(vault kv get -field=azureClientId kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
@@ -99,9 +99,9 @@ arm-template-publish-qa:
   image: $CI_IMAGE
   stage: publish
   tags: ['arch:amd64']
-  #  only:
-  #    refs:
-  #      - main
+  only:
+    refs:
+      - main
   script:
     - ./ci/scripts/arm-template/build_initial_run.py
     - sed -i 's/datadoghq.azurecr.io/lfoqa.azurecr.io/g' ./deploy/azuredeploy.bicep
@@ -112,9 +112,9 @@ arm-template-publish:
   image: $CI_IMAGE
   stage: publish
   tags: ['arch:amd64']
-  #  rules:
-  #    - if: $CI_COMMIT_BRANCH == "main"
-  #      when: manual
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: manual
   variables:
     KUBERNETES_POD_ANNOTATIONS_azure: cloud-iam.emissary.datadoghq.com/azure=88d13348-0530-418a-89c0-9caa32d59037
   script:
@@ -145,9 +145,9 @@ uninstall-script-publish:
 deployer-build-qa:
   image: $DOCKER_IMAGE
   stage: build
-  #  only:
-  #    refs:
-  #      - main
+  only:
+    refs:
+      - main
   tags: ['arch:amd64']
   script:
     - $(vault kv get -field=docker kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3171](https://datadoghq.atlassian.net/browse/AZINTS-3171)

Adds a call to the trigger sync endpoint after uploading the zip package.

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Deployed to https://portal.azure.com/#@devdatadoghq.onmicrosoft.com/resource/subscriptions/34464906-34fe-401e-a420-79bd0ce2a1da/resourceGroups/triggersync/overview

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.


[AZINTS-3171]: https://datadoghq.atlassian.net/browse/AZINTS-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ