### PR TITLE
[AZINTS] make deploy-qa-env always run on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -280,9 +280,9 @@ deploy-qa-env:
   image: $CI_IMAGE
   stage: publish-qa
   tags: ['arch:amd64']
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: manual
+  only:
+    refs:
+      - main
   dependencies:
     - publish-tasks-qa
     - arm-template-publish-qa


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Seems like we should always redeploy the QA env after every merge, hence "QA"

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
