### PR TITLE
[AZINTS] remove readme dependency

### DIFF
--- a/control_plane/pyproject.toml
+++ b/control_plane/pyproject.toml
@@ -2,7 +2,6 @@
 version = "0.0.1"
 name = "azure-log-forwarding-orchestration"
 requires-python = ">= 3.11"
-readme = "README.md"
 
 # common dependencies
 dependencies = [


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Fixes the deployer builds: https://gitlab.ddbuild.io/DataDog/azure-log-forwarding-orchestration/-/jobs/828394172

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
