### PR TITLE
[AZINTS-3170] add more govcloud support

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -86,7 +86,7 @@ from tasks.common import (
     get_managed_env_id,
     get_managed_env_name,
     get_storage_account_name,
-    get_storage_endpoint_suffix,
+    is_azure_gov,
     log_errors,
 )
 from tasks.concurrency import collect, create_task_from_awaitable
@@ -406,7 +406,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
         if len(keys) == 0:
             raise ValueError("No keys found for storage account")
         key: str = keys[0].value  # type: ignore
-        endpoint_suffix = get_storage_endpoint_suffix(storage_account_region)
+        endpoint_suffix = "core.{}.net".format("usgovcloudapi" if is_azure_gov(storage_account_region) else "windows")
         return f"DefaultEndpointsProtocol=https;AccountName={storage_account_name};AccountKey={key};EndpointSuffix={endpoint_suffix}"
 
     async def delete_log_forwarder(self, forwarder_id: str, *, raise_error: bool = True, max_attempts: int = 3) -> bool:

--- a/control_plane/tasks/common.py
+++ b/control_plane/tasks/common.py
@@ -21,8 +21,6 @@ FORWARDER_CONTAINER_APP_PREFIX: Final = "dd-log-forwarder-"
 FORWARDER_MANAGED_ENVIRONMENT_PREFIX: Final = "dd-log-forwarder-env-"
 FORWARDER_STORAGE_ACCOUNT_PREFIX: Final = "ddlogstorage"
 
-AZURE_PUBLIC_STORAGE_ENDPOINT_SUFFIX: Final = "core.windows.net"
-AZURE_GOV_STORAGE_ENDPOINT_SUFFIX: Final = "core.usgovcloudapi.net"
 
 # TODO We will need to add prefixes for these when we implement event hub support
 EVENT_HUB_NAME_PREFIX: Final = NotImplemented
@@ -69,10 +67,9 @@ def get_storage_account_id(subscription_id: str, resource_group: str, config_id:
     ).lower()
 
 
-def get_storage_endpoint_suffix(region: str) -> str:
-    if region.startswith("usgov"):
-        return AZURE_GOV_STORAGE_ENDPOINT_SUFFIX
-    return AZURE_PUBLIC_STORAGE_ENDPOINT_SUFFIX
+# https://learn.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure
+def is_azure_gov(region: str) -> bool:
+    return region.startswith("usgov")
 
 
 def get_event_hub_name(config_id: str) -> str:  # pragma: no cover

--- a/control_plane/tasks/tests/common.py
+++ b/control_plane/tasks/tests/common.py
@@ -31,7 +31,8 @@ class TaskTestCase(AsyncTestCase):
         return self.patch_path(f"tasks.{self.TASK_NAME}.{obj}", **kwargs)
 
     def setUp(self) -> None:
-        self.credential = self.patch_path("tasks.task.DefaultAzureCredential")
+        cred_mock = self.patch_path("tasks.task.DefaultAzureCredential", return_value=AsyncMockClient())
+        self.credential = cred_mock.return_value
         self.credential.side_effect = AsyncMock
         self.datadog_api_client = self.patch_path("tasks.task.AsyncApiClient", return_value=AsyncMockClient())
         self.datadog_logs_api = self.patch_path("tasks.task.LogsApi", return_value=AsyncMock())


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-3170

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

More tests.

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
