### PR TITLE
[AZINTS-3264][diagnostic settings] only call create event within error handling

### DIFF
--- a/control_plane/tasks/diagnostic_settings_task.py
+++ b/control_plane/tasks/diagnostic_settings_task.py
@@ -161,7 +161,7 @@ class DiagnosticSettingsTask(Task):
         )
 
         try:
-            response: EventCreateResponse = await self.events_api.create_event(body)
+            response: EventCreateResponse = await self.events_api.create_event(body)  # type: ignore
         except Exception as e:
             self.log.error(f"Error while sending event to Datadog: {e}")
             return False


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3264](https://datadoghq.atlassian.net/browse/AZINTS-3264)
Removes a call to Datadog that was happening outside of our error handling.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Deployed in Azure. 
Before 
<img width="1853" alt="Screenshot 2025-03-12 at 12 57 42 PM" src="https://github.com/user-attachments/assets/e6531eaa-285d-443f-9463-3e9be5fc6954" />
After

<img width="813" alt="Screenshot 2025-03-12 at 12 39 11 PM" src="https://github.com/user-attachments/assets/397c1c65-6720-4024-b602-04ad6f7640aa" />

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3264]: https://datadoghq.atlassian.net/browse/AZINTS-3264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ