### PR TITLE
[AZINTS-3209][forwarder] enable gzip compression

### DIFF
--- a/forwarder/internal/logs/logs.go
+++ b/forwarder/internal/logs/logs.go
@@ -404,7 +404,11 @@ func (c *Client) AddFormattedLog(ctx context.Context, logger *log.Entry, log dat
 // Flush sends all buffered logs to the Datadog API.
 func (c *Client) Flush(ctx context.Context) (err error) {
 	if len(c.logsBuffer) > 0 {
-		_, _, err = c.logsSubmitter.SubmitLog(ctx, c.logsBuffer)
+		// Enable gzip compression for the payload
+		optionalParams := datadogV2.SubmitLogOptionalParameters{
+			ContentEncoding: datadogV2.CONTENTENCODING_GZIP.Ptr(),
+		}
+		_, _, err = c.logsSubmitter.SubmitLog(ctx, c.logsBuffer, optionalParams)
 
 		if err != nil {
 			c.FailedLogs = append(c.FailedLogs, c.logsBuffer...)


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3209](https://datadoghq.atlassian.net/browse/AZINTS-3209)

Enables gzip compression. The DD client will do the compression internally [here](https://github.com/DataDog/datadog-api-client-go/blob/master/api/datadog/client.go#L328). 

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3209]: https://datadoghq.atlassian.net/browse/AZINTS-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ