### PR TITLE
[AZINTS-3243][forwarder] change source from resource type to provider

### DIFF
--- a/forwarder/cmd/forwarder/forwarder_test.go
+++ b/forwarder/cmd/forwarder/forwarder_test.go
@@ -234,7 +234,7 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, int64(0), finalCursors.Get(containerName, *expiredBlob.Name))
 		for _, logItem := range submittedLogs {
 			assert.Equal(t, logs.AzureService, *logItem.Service)
-			assert.Equal(t, "azure.web.sites", *logItem.Ddsource)
+			assert.Equal(t, "azure.web", *logItem.Ddsource)
 			assert.Contains(t, *logItem.Ddtags, "forwarder:lfo")
 		}
 	})
@@ -305,7 +305,7 @@ func TestRun(t *testing.T) {
 
 		for _, logItem := range submittedLogs {
 			assert.Equal(t, logs.AzureService, *logItem.Service)
-			assert.Equal(t, "azure.web.sites", *logItem.Ddsource)
+			assert.Equal(t, "azure.web", *logItem.Ddsource)
 			assert.Contains(t, *logItem.Ddtags, "forwarder:lfo")
 		}
 	})
@@ -359,7 +359,7 @@ func TestProcessLogs(t *testing.T) {
 		assert.Len(t, submittedLogs, 3)
 		for _, logItem := range submittedLogs {
 			assert.Equal(t, logs.AzureService, *logItem.Service)
-			assert.Equal(t, "azure.web.sites", *logItem.Ddsource)
+			assert.Equal(t, "azure.web", *logItem.Ddsource)
 			assert.Contains(t, *logItem.Ddtags, "forwarder:lfo")
 		}
 	})

--- a/forwarder/internal/logs/logs.go
+++ b/forwarder/internal/logs/logs.go
@@ -162,8 +162,8 @@ func (l *azureLog) ResourceId() *arm.ResourceID {
 }
 
 func sourceTag(resourceType string) string {
-	tag := strings.ToLower(strings.Replace(resourceType, "/", ".", -1))
-	return strings.Replace(tag, "microsoft.", "azure.", -1)
+	parts := strings.Split(strings.ToLower(resourceType), "/")
+	return strings.Replace(parts[0], "microsoft.", "azure.", -1)
 }
 
 func (l *azureLog) ToLog(scrubber Scrubber) *Log {

--- a/forwarder/internal/logs/logs_test.go
+++ b/forwarder/internal/logs/logs_test.go
@@ -95,11 +95,11 @@ func TestAddLog(t *testing.T) {
 func assertTags(t *testing.T, log *logs.Log) {
 	assert.Contains(t, log.Tags, "forwarder:lfo")
 	assert.Contains(t, log.Tags, "subscription_id:0B62A232-B8DB-4380-9DA6-640F7272ED6D")
-	assert.Contains(t, log.Tags, "source:azure.web.sites")
+	assert.Contains(t, log.Tags, "source:azure.web")
 	assert.Contains(t, log.Tags, "resource_group:FORWARDER-INTEGRATION-TESTING")
 	assert.Contains(t, log.Tags, "control_plane_id:")
 	assert.Contains(t, log.Tags, "config_id:")
-	assert.Contains(t, log.Source, "azure.web.sites")
+	assert.Contains(t, log.Source, "azure.web")
 	assert.Contains(t, log.Service, logs.AzureService)
 }
 
@@ -221,7 +221,7 @@ func TestNewLog(t *testing.T) {
 	t.Run("Creates a valid log for plaintext logs outside of function app logs", func(t *testing.T) {
 		t.Parallel()
 		// GIVEN
-		expectedTags := append(logs.DefaultTags, "subscription_id:0b62a232-b8db-4380-9da6-640f7272ed6d", "resource_group:forwarder-integration-testing", "source:azure.web.sites")
+		expectedTags := append(logs.DefaultTags, "subscription_id:0b62a232-b8db-4380-9da6-640f7272ed6d", "resource_group:forwarder-integration-testing", "source:azure.web")
 
 		// WHEN
 		plainTextLog, err := logs.NewLog(plaintextLog, "something normal", resourceId, MockScrubber(t, plaintextLog))
@@ -231,7 +231,7 @@ func TestNewLog(t *testing.T) {
 		assert.NotNil(t, plainTextLog)
 		assert.Equal(t, string(plaintextLog), plainTextLog.Content())
 		assert.Equal(t, resourceId, plainTextLog.ResourceId)
-		assert.Equal(t, "azure.web.sites", plainTextLog.Source)
+		assert.Equal(t, "azure.web", plainTextLog.Source)
 		assert.Empty(t, plainTextLog.Category)
 		assert.Equal(t, expectedTags, plainTextLog.Tags)
 		assert.Equal(t, logs.AzureService, plainTextLog.Service)


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3243](https://datadoghq.atlassian.net/browse/AZINTS-3243)

Updates our source to be the resource provider instead of resource type. This is inline with liftr and activity log forwarder and enables our log remapping to work properly.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Deployed to my LFO and saw logs from it had variable delay again
https://app.datadoghq.com/s/yB5yjZ/juh-rgs-i2w

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3243]: https://datadoghq.atlassian.net/browse/AZINTS-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ