### PR TITLE
[Initial Run] Write script to file before execution 

### DIFF
--- a/ci/scripts/control_plane/build_initial_run.py
+++ b/ci/scripts/control_plane/build_initial_run.py
@@ -34,7 +34,8 @@ script_content = f"""#!/usr/bin/env bash
 set -euo pipefail
 curl https://bootstrap.pypa.io/get-pip.py | python3
 pip install {" ".join(deps)} > /dev/null
-python3 -c '{python_content}'
+echo '{python_content}' > initial_run_script.py
+python3 initial_run_script.py
 """
 
 with open(INITIAL_RUN_SCRIPT, "w") as f:


### PR DESCRIPTION
## Description
Running the `deploy_personal_env.py` was hitting this error when trying to create the deployment script resource for the initial run script:
`"code":"DeploymentScriptError","message":"initial_run.sh: line 6: /usr/bin/python3: Argument list too long"`

This change converts the execution of the python initial run script from a command line argument to a file. 
```
echo '{python_content}' > initial_run_script.py
python3 initial_run_script.py
```

This command below also works, but writing to a file feels safer.
```
echo '{python_content}' | python3 -
```

Jira issue: 

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [x] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
Ran against problematic branch where control plane code had grown too large to run the initial run script with previous method.

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
