### PR TITLE
[deployer] move to internal registry for image

### DIFF
--- a/ci/deployer-task/Dockerfile
+++ b/ci/deployer-task/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM registry.ddbuild.io/images/mirror/python:3.11.5-alpine3.18
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Swaps out the docker hub image for an internal one to prevent rate limits in CI

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
