### PR TITLE
[AZINTS-3231] add a contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Pull requests should be labelled with at least a component, in addition to the t
 > Always add a `comp:` and a `type:` label.
 
 >[!NOTE]
-> For reference, the [full list of all labels available](https://github.com/DataDog/dd-trace-java/labels).
+> For reference, the [full list of all labels available](https://github.com/DataDog/azure-log-forwarding-orchestration/labels).
 
 ## Pull request reviews
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3231](https://datadoghq.atlassian.net/browse/AZINTS-3231)

Adds a contributing file similar to the [Java APM Client](https://github.com/DataDog/dd-trace-java)

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3231]: https://datadoghq.atlassian.net/browse/AZINTS-3231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ