### PR TITLE
[AZINTS] fix deployer dependency installation

### DIFF
--- a/ci/deployer-task/Dockerfile
+++ b/ci/deployer-task/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.ddbuild.io/images/mirror/python:3.11.5-alpine3.18
 RUN mkdir /app
 WORKDIR /app
 # Download dependencies
+RUN pip install --upgrade pip
 COPY ./pyproject.toml ./pyproject.toml
 RUN python3.11 -m pip install -e '.[deployer_task]'
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

fixes the following problem with the deployer task caused by deployer specific dependencies not being installed properly
```
Traceback (most recent call last):
File "<frozen runpy>", line 198, in _run_module_as_main
File "<frozen runpy>", line 88, in _run_code
File "/app/tasks/deployer_task.py", line 11, in <module>
from azure.mgmt.storage.v2023_05_01.aio import StorageManagementClient
ModuleNotFoundError: No module named 'azure.mgmt'
Traceback (most recent call last):
File "<frozen runpy>", line 198, in _run_module_as_main
File "<frozen runpy>", line 88, in _run_code
File "/app/tasks/deployer_task.py", line 11, in <module>
from azure.mgmt.storage.v2023_05_01.aio import StorageManagementClient
ModuleNotFoundError: No module named 'azure.mgmt'
```

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

Tested locally and in personal env:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/V1pjTLXO6A0xXPFWXzr5/f700ed01-b1f6-4f43-a045-d33ecf64d046.png)

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
