### PR TITLE
correct incorrect conversions between integer types

### DIFF
--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -263,7 +263,7 @@ func processDeadLetterQueue(ctx context.Context, logger *log.Entry, storageClien
 	return dlq.Save(ctx, storageClient, logger)
 }
 
-func run(ctx context.Context, logParent *log.Logger, goroutineCount int64, datadogConfig *datadog.Configuration, azBlobClient storage.AzureBlobClient, piiScrubber logs.Scrubber, now customtime.Now, versionTag string) error {
+func run(ctx context.Context, logParent *log.Logger, goroutineCount int, datadogConfig *datadog.Configuration, azBlobClient storage.AzureBlobClient, piiScrubber logs.Scrubber, now customtime.Now, versionTag string) error {
 	start := time.Now()
 
 	datadogConfig.AddDefaultHeader("dd_evp_origin", "lfo")
@@ -347,7 +347,7 @@ func main() {
 	if goroutineString == "" {
 		goroutineString = "10"
 	}
-	goroutineCount, err := strconv.ParseInt(goroutineString, 10, 64)
+	goroutineCount, err := strconv.Atoi(goroutineString)
 	if err != nil {
 		logger.Fatal(fmt.Errorf("error parsing %s: %w", environment.NumGoroutines, err).Error())
 	}


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->
This PR is to correct a code scanning issue found here https://github.com/DataDog/azure-log-forwarding-orchestration/security/code-scanning/3

Previously we were converting a 64bit integer to a 32bit one.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
