### PR TITLE
upgrade aiohttp

### DIFF
--- a/control_plane/pyproject.toml
+++ b/control_plane/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">= 3.11"
 
 # common dependencies
 dependencies = [
-    "aiohttp==3.11.14",
+    "aiohttp==3.11.16",
     "azure-identity==1.16.1",
     "azure-storage-blob==12.20.0",
     "datadog-api-client[async]==2.26.0",


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

3.11.14 has been yanked due to a regression. Upgrade to latest. 
https://pypi.org/project/aiohttp/#history
https://github.com/aio-libs/aiohttp/issues/10617

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Deployed to personal env and verified tasks can still execute
https://portal.azure.com/#view/WebsitesExtension/FunctionTabMenuBlade/~/invocations/resourceId/%2Fsubscriptions%2F34464906-34fe-401e-a420-79bd0ce2a1da%2FresourceGroups%2Flfomaert%2Fproviders%2FMicrosoft.Web%2Fsites%2Fresources-task-d0105e57d837%2Ffunctions%2Fresources_task

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
