### PR TITLE
ignore generated mocks for copyright headers

### DIFF
--- a/ci/scripts/licensing/add_copyright_header.py
+++ b/ci/scripts/licensing/add_copyright_header.py
@@ -13,6 +13,7 @@ from datetime import datetime
 IGNORED_FOLDERS: list[str] = [
     ".git",
     "dist",
+    "mocks",
     "node_modules",
     "venv",
 ]


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3232](https://datadoghq.atlassian.net/browse/AZINTS-3232)

Ignore mocks directories when adding headers. These will always be generated.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3232]: https://datadoghq.atlassian.net/browse/AZINTS-3232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ