### PR TITLE
remove commented out blank lines

### DIFF
--- a/ci/scripts/licensing/add_copyright_header.py
+++ b/ci/scripts/licensing/add_copyright_header.py
@@ -90,7 +90,7 @@ def create_header(template_text: str, comment_char: str) -> str:
     header_text = template_text.replace("$year", str(year))
 
     # Split into lines and add comment prefix based on file type
-    commented_lines = [f"{comment_char} {line}" for line in header_text.splitlines()]
+    commented_lines = [f"{comment_char} {line}" if line.strip() else "" for line in header_text.splitlines()]
 
     return "\n".join(commented_lines) + "\n\n"
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3232](https://datadoghq.atlassian.net/browse/AZINTS-3232)

Noticed when I opened a PR to add these headers that they commented a blank line. This ensures that a blank line stays blank.


This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3232]: https://datadoghq.atlassian.net/browse/AZINTS-3232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ