### PR TITLE
add job to check copyright headers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,7 +214,17 @@ forwarder-format:
     - cd forwarder
     - go fmt ./...
     - git diff --exit-code
-# ------------- CODE QUALITY -------------
+copyright-headers:
+  image: $CI_IMAGE
+  stage: test
+  tags: ['arch:amd64']
+  dependencies:
+    - control-plane-formatting
+    - forwarder-vet
+  script:
+    - ci/scripts/licensing/add_copyright_header.py
+    - git diff --exit-code
+# ------------- CODE COV -------------
 coverage-comment:
   image: $PR_COMMENTER_IMAGE
   stage: build
@@ -227,16 +237,6 @@ coverage-comment:
     - control-plane-tests
   script:
     - ci/scripts/coverage-comment.sh
-copyright-headers:
-  image: $CI_IMAGE
-  stage: build
-  tags: ['arch:amd64']
-  dependencies:
-    - forwarder-tests
-    - control-plane-tests
-  script:
-    - ci/scripts/licensing/add_copyright_header.py
-    - git diff --exit-code
 # ------------- QA ENV -------------
 forwarder-build-qa:
   image: $DOCKER_IMAGE


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3232](https://datadoghq.atlassian.net/browse/AZINTS-3232)

This PR adds job to check if the copyright header has been added to the appropriate files.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3232]: https://datadoghq.atlassian.net/browse/AZINTS-3232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ