### PR TITLE
[CI] Remove debug flags from forwarder build command

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,9 +170,9 @@ forwarder-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
   tags: ['arch:amd64']
-  # only:
-  #   refs:
-  #     - main
+  only:
+    refs:
+      - main
   script:
     - ci/scripts/forwarder/build_and_push.sh $INTERNAL_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 forwarder-publish:


### PR DESCRIPTION
## Description
Utilize `ldflags` to reduce the size of the forwarder binary

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-3236

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
Manually tested: https://gitlab.ddbuild.io/DataDog/azure-log-forwarding-orchestration/-/jobs/898305575

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
