### PR TITLE
Matt.spurlin/fix deployer versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,7 @@ deployer-build-tagged:
       - main
   tags: ['arch:amd64']
   script:
-    - docker buildx build --platform=linux/amd64 --tag $INTERNAL_DOCKER_REGISTRY/deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} -f "ci/deployer-task/Dockerfile" ./control_plane --push
+    - docker buildx build --platform=linux/amd64 --build-arg VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag $INTERNAL_DOCKER_REGISTRY/deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} -f "ci/deployer-task/Dockerfile" ./control_plane --push
 deployer-publish:
   stage: publish
   rules:
@@ -305,7 +305,7 @@ deployer-build-qa:
   tags: ['arch:amd64']
   script:
     - $(vault kv get -field=docker kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
-    - docker buildx build --platform=linux/amd64 -build-arg VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag $QA_DOCKER_REGISTRY/deployer:latest -f "ci/deployer-task/Dockerfile" ./control_plane --push
+    - docker buildx build --platform=linux/amd64 --build-arg VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag $QA_DOCKER_REGISTRY/deployer:latest -f "ci/deployer-task/Dockerfile" ./control_plane --push
 uninstall-script-publish-qa:
   image: $CI_IMAGE
   stage: publish-qa


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Corrects an issue where all deployer images have the version tag reporting as latest in the QA environment.
Look at QA over the past day and you should see everything else had version tags change
https://app.datadoghq.com/dashboard/rff-fs6-kxq/logs-azure-lfo-health?fromUser=true&refresh_mode=sliding&tpl_var_control_plane_id%5B0%5D=db751049441a&tpl_var_internal_orgs%5B0%5D=2&tpl_var_internal_orgs%5B1%5D=1200033880&tpl_var_internal_orgs%5B2%5D=1204426&tpl_var_internal_orgs%5B3%5D=378637&tpl_var_internal_orgs%5B4%5D=447397&tpl_var_logforwarder%5B0%5D=%2A&tpl_var_org_id%5B0%5D=%2A&tpl_var_region%5B0%5D=%2A&tpl_var_task%5B0%5D=%2A&from_ts=1746039224960&to_ts=1746125624960&live=true

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
