### PR TITLE
pass dd telemetry setting to forwarders

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -162,7 +162,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
         self.forwarder_image = get_config_option(FORWARDER_IMAGE_SETTING)
         self.dd_api_key = get_config_option(DD_API_KEY_SETTING)
         self.dd_site = get_config_option(DD_SITE_SETTING)
-        self.dd_telemetry = is_truthy(DD_TELEMETRY_SETTING)
+        self.telemetry_enabled = is_truthy(DD_TELEMETRY_SETTING)
         self.control_plane_region = get_config_option(CONTROL_PLANE_REGION_SETTING)
         self.control_plane_id = get_config_option(CONTROL_PLANE_ID_SETTING)
         self.log = log
@@ -385,7 +385,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
             EnvironmentVar(name=CONTROL_PLANE_ID_SETTING, value=self.control_plane_id),
             EnvironmentVar(name=CONFIG_ID_SETTING, value=config_id),
             EnvironmentVar(name=PII_SCRUBBER_RULES_SETTING, value=self.pii_rules_json),
-            EnvironmentVar(name=DD_TELEMETRY_SETTING, value=str(self.dd_telemetry).lower()),
+            EnvironmentVar(name=DD_TELEMETRY_SETTING, value=str(self.telemetry_enabled).lower()),
         ]
 
     async def create_log_forwarder_containers(self, storage_account_name: str) -> None:
@@ -594,7 +594,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
     async def submit_log_forwarder_metrics(
         self, log_forwarder_id: str, metrics: list[MetricBlobEntry], region: str
     ) -> None:
-        if not self.dd_telemetry or not metrics:
+        if not self.telemetry_enabled or not metrics:
             return
 
         response: IntakePayloadAccepted = await self.metrics_client.submit_metrics(

--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -620,7 +620,7 @@ class TestLogForwarderClient(AsyncTestCase):
         )
 
     async def test_submit_metrics_normal_execution(self):
-        self.client.dd_telemetry = True
+        self.client.telemetry_enabled = True
         self.client.metrics_client.submit_metrics.return_value = {}
         async with self.client as client:
             await client.submit_log_forwarder_metrics("test", FAKE_METRIC_BLOBS, EAST_US)
@@ -628,7 +628,7 @@ class TestLogForwarderClient(AsyncTestCase):
         self.client.metrics_client.submit_metrics.assert_called_once_with(body=FAKE_METRIC_PAYLOAD)
 
     async def test_submit_metrics_retries(self):
-        self.client.dd_telemetry = True
+        self.client.telemetry_enabled = True
         self.client.metrics_client.submit_metrics.side_effect = [RequestTimeout(), RequestTimeout(), DEFAULT]
         self.client.metrics_client.submit_metrics.return_value = {}
         self.client.metrics_client.submit_metrics.side_effect = RequestTimeout()
@@ -641,7 +641,7 @@ class TestLogForwarderClient(AsyncTestCase):
         self.assertIsInstance(ctx.exception.last_attempt.exception(), RequestTimeout)
 
     async def test_submit_metrics_nonretryable_exception(self):
-        self.client.dd_telemetry = True
+        self.client.telemetry_enabled = True
         self.client.metrics_client.submit_metrics.side_effect = FakeHttpError(404)
         with self.assertRaises(FakeHttpError):
             async with self.client as client:
@@ -660,7 +660,7 @@ class TestLogForwarderClient(AsyncTestCase):
         self.assertEqual(res, [])
 
     async def test_submit_metrics_errors_logged(self):
-        self.client.dd_telemetry = True
+        self.client.telemetry_enabled = True
         self.client.metrics_client.submit_metrics.return_value = {
             "errors": [
                 "oops something went wrong",


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: [AZINTS-3449](https://datadoghq.atlassian.net/browse/AZINTS-3449)
This PR passes the DD_TELEMETRY setting down to log forwarders upon creation. We likely will want to figure out keeping these in sync at some point. But this will unblock getting staging to work with the forwarder.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Unit tests and deployed to personal env.

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.


[AZINTS-3449]: https://datadoghq.atlassian.net/browse/AZINTS-3449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ