### PR TITLE
add better staging support

### DIFF
--- a/control_plane/tasks/client/resource_client.py
+++ b/control_plane/tasks/client/resource_client.py
@@ -26,7 +26,7 @@ from azure.mgmt.resource.resources.v2021_01_01.aio import ResourceManagementClie
 from azure.mgmt.resource.resources.v2021_01_01.models import GenericResourceExpanded
 from azure.mgmt.sql.aio import SqlManagementClient
 from azure.mgmt.synapse.aio import SynapseManagementClient
-from azure.mgmt.web.aio import WebSiteManagementClient
+from azure.mgmt.web.v2024_04_01.aio import WebSiteManagementClient
 
 # project
 from cache.resources_cache import RegionToResourcesDict, ResourceMetadata

--- a/control_plane/tasks/client/resource_client.py
+++ b/control_plane/tasks/client/resource_client.py
@@ -26,7 +26,7 @@ from azure.mgmt.resource.resources.v2021_01_01.aio import ResourceManagementClie
 from azure.mgmt.resource.resources.v2021_01_01.models import GenericResourceExpanded
 from azure.mgmt.sql.aio import SqlManagementClient
 from azure.mgmt.synapse.aio import SynapseManagementClient
-from azure.mgmt.web.v2024_04_01.aio import WebSiteManagementClient
+from azure.mgmt.web.aio import WebSiteManagementClient
 
 # project
 from cache.resources_cache import RegionToResourcesDict, ResourceMetadata

--- a/control_plane/tasks/task.py
+++ b/control_plane/tasks/task.py
@@ -74,7 +74,7 @@ class ListHandler(Handler):
 
 def _add_datadog_staging(settings: list[dict[str, Any]]) -> None:
     """takes a list of settings and adds datad0g.com to the list of supported sites"""
-    if not settings:
+    if not settings or not isinstance(settings, list):
         return
     supported_sites = settings[0].get("variables", {}).get("site", {}).get("enum_values", [])
     if len(supported_sites) > 1:

--- a/control_plane/tasks/task.py
+++ b/control_plane/tasks/task.py
@@ -72,7 +72,7 @@ class ListHandler(Handler):
         self.log_list.append(record)
 
 
-def _add_datadog_staging(settings: list[dict[str, Any]]) -> None:
+def _add_datadog_staging(settings: list[dict[str, Any]] | None) -> None:
     """takes a list of settings and adds datad0g.com to the list of supported sites"""
     if not settings or not isinstance(settings, list):
         return

--- a/control_plane/tasks/task.py
+++ b/control_plane/tasks/task.py
@@ -12,7 +12,7 @@ from os import environ
 from time import time
 from traceback import format_exception
 from types import TracebackType
-from typing import Self
+from typing import Any, Self
 from uuid import uuid4
 
 # 3p
@@ -72,6 +72,15 @@ class ListHandler(Handler):
         self.log_list.append(record)
 
 
+def _add_datadog_staging(settings: list[dict[str, Any]]) -> None:
+    """takes a list of settings and adds datad0g.com to the list of supported sites"""
+    if not settings:
+        return
+    supported_sites = settings[0].get("variables", {}).get("site", {}).get("enum_values", [])
+    if len(supported_sites) > 1:
+        supported_sites.append("datad0g.com")
+
+
 class Task(AbstractAsyncContextManager["Task"]):
     NAME: str
 
@@ -93,13 +102,25 @@ class Task(AbstractAsyncContextManager["Task"]):
         self.log = log.getChild(self.__class__.__name__)
         self._logs: list[LogRecord] = []
         configuration = Configuration()
+
         if self.telemetry_enabled:
             configuration.server_index = 2
             configuration.server_variables["site"] = "datad0g.com"
+
+            host_settings = configuration.get_host_settings()
+            _add_datadog_staging(host_settings)
+            configuration.get_host_settings = lambda: host_settings
+
         self._datadog_client = AsyncApiClient(configuration)
         self._logs_client = LogsApi(self._datadog_client)
         self._metrics_client = MetricsApi(self._datadog_client)
         if self.telemetry_enabled:
+            logs_servers = self._logs_client._submit_log_endpoint.settings.get("servers")
+            _add_datadog_staging(logs_servers)
+
+            metrics_servers = self._metrics_client._submit_metrics_endpoint.settings.get("servers")
+            _add_datadog_staging(metrics_servers)
+
             log.info("Telemetry enabled, will submit logs for %s", self.NAME)
             self.log.addHandler(ListHandler(self._logs))
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Adds even more support for staging environments. Looking at our previous executions can see that it is not reporting to staging successful
https://portal.azure.com/#view/WebsitesExtension/FunctionTabMenuBlade/~/invocations/resourceId/%2Fsubscriptions%2F0b62a232-b8db-4380-9da6-640f7272ed6d%2FresourceGroups%2Flfostaging%2Fproviders%2FMicrosoft.Web%2Fsites%2Fresources-task-1e78f83b720d%2Ffunctions%2Fresources_task

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
