### PR TITLE
only force datad0g when intended

### DIFF
--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -150,6 +150,7 @@ class TestLogForwarderClient(AsyncTestCase):
         p.start()
         self.addCleanup(p.stop)
         self.log = mock()
+        self.metrics_client = Mock()
         self.client: MockedLogForwarderClient = cast(
             MockedLogForwarderClient,
             LogForwarderClient(
@@ -158,6 +159,7 @@ class TestLogForwarderClient(AsyncTestCase):
                 subscription_id=SUB_ID1,
                 resource_group=RESOURCE_GROUP_NAME,
                 pii_rules_json=PII_RULES_JSON,
+                metrics_client=self.metrics_client,
             ),
         )
         await self.client.__aexit__(None, None, None)
@@ -330,13 +332,7 @@ class TestLogForwarderClient(AsyncTestCase):
             await sleep(0.05)
             m()
 
-        async with LogForwarderClient(
-            self.log,
-            Mock(),
-            "sub1",
-            "rg1",
-            PII_RULES_JSON,
-        ) as client:
+        async with LogForwarderClient(self.log, Mock(), "sub1", "rg1", PII_RULES_JSON, Mock()) as client:
             for _ in range(3):
                 client.submit_background_task(background_task())
             failing_task_error = Exception("test")

--- a/control_plane/tasks/scaling_task.py
+++ b/control_plane/tasks/scaling_task.py
@@ -172,7 +172,7 @@ class ScalingTask(Task):
         regions_to_remove = provisioned_regions - regions_with_resources
         regions_to_check_scaling = regions_with_resources & regions_with_forwarders
         async with LogForwarderClient(
-            self.log, self.credential, subscription_id, self.resource_group, self.pii_rules_json
+            self.log, self.credential, subscription_id, self.resource_group, self.pii_rules_json, self._metrics_client
         ) as client:
             await gather(
                 *(self.set_up_region(client, subscription_id, region) for region in regions_to_add),

--- a/control_plane/tasks/task.py
+++ b/control_plane/tasks/task.py
@@ -31,6 +31,7 @@ from cache.common import read_cache
 from cache.env import (
     CONTROL_PLANE_ID_SETTING,
     DD_API_KEY_SETTING,
+    DD_SITE_SETTING,
     DD_TELEMETRY_SETTING,
     LOG_LEVEL_SETTING,
     VERSION_TAG_SETTING,
@@ -104,8 +105,9 @@ class Task(AbstractAsyncContextManager["Task"]):
         configuration = Configuration()
 
         if self.telemetry_enabled:
-            configuration.server_index = 2
-            configuration.server_variables["site"] = "datad0g.com"
+            if "datad0g.com" in environ.get(DD_SITE_SETTING, ""):
+                configuration.server_index = 2
+                configuration.server_variables["site"] = "datad0g.com"
 
             host_settings = configuration.get_host_settings()
             _add_datadog_staging(host_settings)

--- a/control_plane/tasks/task.py
+++ b/control_plane/tasks/task.py
@@ -104,10 +104,11 @@ class Task(AbstractAsyncContextManager["Task"]):
         self._logs: list[LogRecord] = []
         configuration = Configuration()
 
-        if self.telemetry_enabled:
-            if "datad0g.com" in environ.get(DD_SITE_SETTING, ""):
-                configuration.server_index = 2
-                configuration.server_variables["site"] = "datad0g.com"
+        target_staging = self.telemetry_enabled and "datad0g.com" in environ.get(DD_SITE_SETTING, "")
+
+        if target_staging:
+            configuration.server_index = 2
+            configuration.server_variables["site"] = "datad0g.com"
 
             host_settings = configuration.get_host_settings()
             _add_datadog_staging(host_settings)
@@ -116,13 +117,14 @@ class Task(AbstractAsyncContextManager["Task"]):
         self._datadog_client = AsyncApiClient(configuration)
         self._logs_client = LogsApi(self._datadog_client)
         self._metrics_client = MetricsApi(self._datadog_client)
-        if self.telemetry_enabled:
+        if target_staging:
             logs_servers = self._logs_client._submit_log_endpoint.settings.get("servers")
             _add_datadog_staging(logs_servers)
 
             metrics_servers = self._metrics_client._submit_metrics_endpoint.settings.get("servers")
             _add_datadog_staging(metrics_servers)
 
+        if self.telemetry_enabled:
             log.info("Telemetry enabled, will submit logs for %s", self.NAME)
             self.log.addHandler(ListHandler(self._logs))
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

This PR makes it so that we only target datad0g.com when actually intended. Previously when telemetry was enabled we'd force submission to datad0g.com for any task reported metric.

This change affects:
 - [x] Control Plane Tasks
 - [x] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Tested by running the task with various environment variables set and updated unit tests to account for the new variable at instantiation. 

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
