### PR TITLE
[LFO][Forwarder] Enforce 45s timeout in forwarder

### DIFF
--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -142,10 +142,10 @@ func getLogBytes(ctx context.Context, resourceBytesCh <-chan resourceBytes) map[
 
 func writeMetrics(ctx context.Context, storageClient *storage.Client, resourceVolumes map[string]int64, resourceBytes map[string]int64, startTime time.Time, versionTag string) (int, error) {
 	if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
-		// We should always write metrics even if error/timeout occurred already. Use new context if so.
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Always write metrics even if timeout occurred - use new context if so
+		writeMetricCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		ctx = timeoutCtx
+		ctx = writeMetricCtx
 	}
 
 	metricBlob := metrics.MetricEntry{

--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -141,12 +141,11 @@ func getLogBytes(ctx context.Context, resourceBytesCh <-chan resourceBytes) map[
 }
 
 func writeMetrics(ctx context.Context, storageClient *storage.Client, resourceVolumes map[string]int64, resourceBytes map[string]int64, startTime time.Time, versionTag string) (int, error) {
-	metricWriteCtx := ctx
 	if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
 		// We should always write metrics even if error/timeout occurred already. Use new context if so.
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		metricWriteCtx = timeoutCtx
+		ctx = timeoutCtx
 	}
 
 	metricBlob := metrics.MetricEntry{
@@ -164,7 +163,7 @@ func writeMetrics(ctx context.Context, storageClient *storage.Client, resourceVo
 
 	blobName := metrics.GetMetricFileName(time.Now())
 
-	_ = storageClient.AppendBlob(metricWriteCtx, storage.ForwarderContainer, blobName, metricBuffer)
+	_ = storageClient.AppendBlob(ctx, storage.ForwarderContainer, blobName, metricBuffer)
 
 	logCount := 0
 	for _, v := range resourceVolumes {

--- a/forwarder/cmd/forwarder/forwarder_test.go
+++ b/forwarder/cmd/forwarder/forwarder_test.go
@@ -185,7 +185,7 @@ func getDatadogConfig(getDatadogLogResp func(req *http.Request) (*http.Response,
 	return datadogConfig, submittedLogsChan
 }
 
-func mockedRun(t *testing.T, containers []*service.ContainerItem, blobs []*container.BlobItem, getDownloadResp func(*azblob.DownloadStreamOptions) azblob.DownloadStreamResponse, cursorResp azblob.DownloadStreamResponse, deadletterqueueResp azblob.DownloadStreamResponse, uploadFunc func(context.Context, string, string, []byte, *azblob.UploadBufferOptions) (azblob.UploadBufferResponse, error), getDatadogLogResp func(req *http.Request) (*http.Response, error), customNow customtime.Now) ([]datadogV2.HTTPLogItem, error) {
+func mockedRun(t *testing.T, ctx context.Context, containers []*service.ContainerItem, blobs []*container.BlobItem, getDownloadResp func(*azblob.DownloadStreamOptions) azblob.DownloadStreamResponse, cursorResp azblob.DownloadStreamResponse, deadletterqueueResp azblob.DownloadStreamResponse, uploadFunc func(context.Context, string, string, []byte, *azblob.UploadBufferOptions) (azblob.UploadBufferResponse, error), getDatadogLogResp func(req *http.Request) (*http.Response, error), customNow customtime.Now) ([]datadogV2.HTTPLogItem, error) {
 	ctrl := gomock.NewController(t)
 	mockClient := storagemocks.NewMockAzureBlobClient(ctrl)
 
@@ -198,18 +198,43 @@ func mockedRun(t *testing.T, containers []*service.ContainerItem, blobs []*conta
 	mockClient.EXPECT().NewListBlobsFlatPager(gomock.Any(), gomock.Any()).Return(blobPager).Times(len(containers))
 
 	mockClient.EXPECT().DownloadStream(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(ctx context.Context, containerName string, blobName string, o *azblob.DownloadStreamOptions) (azblob.DownloadStreamResponse, error) {
-		if blobName == cursor.BlobName {
-			return cursorResp, nil
+		// Check for timed out context
+		if ctx.Err() != nil {
+			return azblob.DownloadStreamResponse{}, ctx.Err()
 		}
-		if blobName == deadletterqueue.BlobName {
-			return deadletterqueueResp, nil
+
+		select {
+		case <-ctx.Done():
+			// Time out occurred
+			return azblob.DownloadStreamResponse{}, ctx.Err()
+		default:
+			if blobName == cursor.BlobName {
+				return cursorResp, nil
+			}
+			if blobName == deadletterqueue.BlobName {
+				return deadletterqueueResp, nil
+			}
+			if strings.Contains(blobName, "metrics_") {
+				resp := azblob.DownloadStreamResponse{}
+				resp.Body = io.NopCloser(strings.NewReader(""))
+				return resp, nil
+			}
+			// Create a channel to allow our test to abort long-running downloads
+			respCh := make(chan azblob.DownloadStreamResponse, 1)
+
+			go func() {
+				resp := getDownloadResp(o)
+				respCh <- resp
+			}()
+
+			// Wait for either the download to complete or context to be canceled
+			select {
+			case resp := <-respCh:
+				return resp, nil
+			case <-ctx.Done():
+				return azblob.DownloadStreamResponse{}, ctx.Err()
+			}
 		}
-		if strings.Contains(blobName, "metrics_") {
-			resp := azblob.DownloadStreamResponse{}
-			resp.Body = io.NopCloser(strings.NewReader(""))
-			return resp, nil
-		}
-		return getDownloadResp(o), nil
 	})
 
 	mockClient.EXPECT().UploadBuffer(gomock.Any(), storage.ForwarderContainer, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(uploadFunc).AnyTimes()
@@ -218,8 +243,6 @@ func mockedRun(t *testing.T, containers []*service.ContainerItem, blobs []*conta
 	mockClient.EXPECT().CreateContainer(gomock.Any(), storage.ForwarderContainer, gomock.Any()).Return(resp, nil).AnyTimes()
 
 	mockPiiScrubber := newMockPiiScrubber(ctrl)
-
-	ctx := context.Background()
 
 	datadogConfig, logsChan := getDatadogConfig(getDatadogLogResp)
 	submittedLogs := make([]datadogV2.HTTPLogItem, 0)
@@ -309,7 +332,7 @@ func TestRun(t *testing.T) {
 		}
 
 		// WHEN
-		submittedLogs, err := mockedRun(t, containerPage, blobPage, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
+		submittedLogs, err := mockedRun(t, context.Background(), containerPage, blobPage, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
 
 		// THEN
 		assert.NoError(t, err)
@@ -394,7 +417,7 @@ func TestRun(t *testing.T) {
 		}
 
 		// WHEN
-		submittedLogs, err := mockedRun(t, containerPage, blobPage, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
+		submittedLogs, err := mockedRun(t, context.Background(), containerPage, blobPage, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
 
 		// THEN
 		assert.NoError(t, err)
@@ -420,6 +443,93 @@ func TestRun(t *testing.T) {
 			assert.Equal(t, "azure.web", *logItem.Ddsource)
 			assert.Contains(t, *logItem.Ddtags, "forwarder:lfo")
 		}
+	})
+
+	t.Run("forwarder timeout is properly enforced", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN
+		testString := "test"
+		validLog := getLogWithContent(testString, 5*time.Minute)
+		expectedBytesForLog := len(validLog)
+
+		containerName := "insights-logs-functionapplogs"
+		containerPage := []*service.ContainerItem{
+			newContainerItem(containerName),
+		}
+		blobPage := []*container.BlobItem{
+			newBlobItem("timeout-test", int64(expectedBytesForLog), time.Now()),
+		}
+
+		slowDownloadDuration := 10 * time.Second
+		forwarderDuration := 10 * time.Millisecond
+
+		getDownloadResp := func(o *azblob.DownloadStreamOptions) azblob.DownloadStreamResponse {
+			time.Sleep(slowDownloadDuration)
+			return azblob.DownloadStreamResponse{
+				DownloadResponse: blob.DownloadResponse{
+					Body: io.NopCloser(strings.NewReader(string(validLog))),
+				},
+			}
+		}
+
+		cursorResp := azblob.DownloadStreamResponse{
+			DownloadResponse: blob.DownloadResponse{
+				Body: io.NopCloser(strings.NewReader("{}")),
+			},
+		}
+
+		deadLetterQueueResp := azblob.DownloadStreamResponse{
+			DownloadResponse: blob.DownloadResponse{
+				Body: io.NopCloser(strings.NewReader("[]")),
+			},
+		}
+
+		var isCursorSaved bool
+		var isMetricSaved bool
+		uploadFunc := func(ctx context.Context, containerName string, blobName string, content []byte, o *azblob.UploadBufferOptions) (azblob.UploadBufferResponse, error) {
+			if strings.Contains(blobName, cursor.BlobName) {
+				isCursorSaved = true
+			}
+			if strings.Contains(blobName, "metrics_") {
+				isMetricSaved = true
+			}
+
+			return azblob.UploadBufferResponse{}, nil
+		}
+
+		logResp := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+
+		// This context with short timeout should trigger the context cancellation behavior in our test
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), forwarderDuration)
+		defer cancel()
+
+		startTime := time.Now()
+
+		customNow := func() time.Time {
+			return time.Now()
+		}
+
+		// WHEN
+		_, err := mockedRun(t, timeoutCtx, containerPage, blobPage, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
+
+		elapsed := time.Since(startTime)
+
+		// THEN
+		require.Error(t, err, "Expected a timeout error")
+		assert.Contains(t, err.Error(), "context deadline exceeded", "Expected deadline exceeded error")
+
+		// Verify that the test is completing shortly after timeout
+		maxExpectedDuration := 2 * time.Second
+		assert.True(t, elapsed < maxExpectedDuration, "Test took %v, which is longer than expected %v", elapsed, maxExpectedDuration)
+
+		// Verify critical operations were still performed despite timeout
+		assert.True(t, isCursorSaved, "Cursor should be saved even after timeout")
+		assert.True(t, isMetricSaved, "Metrics should be saved even after timeout")
 	})
 }
 
@@ -695,7 +805,7 @@ func TestCursors(t *testing.T) {
 			}
 
 			// WHEN
-			submittedLogs, err := mockedRun(t, containerPage, []*container.BlobItem{blobItem}, getDownloadResp, cursorResp, deadLetterQeueResp, uploadFunc, logResp, customNow)
+			submittedLogs, err := mockedRun(t, context.Background(), containerPage, []*container.BlobItem{blobItem}, getDownloadResp, cursorResp, deadLetterQeueResp, uploadFunc, logResp, customNow)
 
 			// THEN
 			assert.NoError(t, err)
@@ -770,7 +880,7 @@ func TestCursors(t *testing.T) {
 			}
 
 			// WHEN
-			submittedLogs, err := mockedRun(t, containerPage, []*container.BlobItem{blobItem}, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
+			submittedLogs, err := mockedRun(t, context.Background(), containerPage, []*container.BlobItem{blobItem}, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
 
 			// THEN
 			assert.NoError(t, err)
@@ -894,7 +1004,7 @@ func TestCursorsOnActiveDirectoryLogs(t *testing.T) {
 			}
 
 			// WHEN
-			submittedLogs, err := mockedRun(t, containerPage, []*container.BlobItem{blobItem}, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
+			submittedLogs, err := mockedRun(t, context.Background(), containerPage, []*container.BlobItem{blobItem}, getDownloadResp, cursorResp, deadLetterQueueResp, uploadFunc, logResp, customNow)
 
 			// THEN
 			assert.NoError(t, err)

--- a/forwarder/internal/cursor/cursor.go
+++ b/forwarder/internal/cursor/cursor.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	// 3p
 	log "github.com/sirupsen/logrus"
@@ -65,11 +66,19 @@ func (c *Cursors) JSONBytes() ([]byte, error) {
 
 // Save saves the cursors to storage
 func (c *Cursors) Save(ctx context.Context, client *storage.Client) error {
+	cursorSaveCtx := ctx
+	if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
+		// Always save cursors - use a new context if error/timeout occurred already
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cursorSaveCtx = timeoutCtx
+	}
+
 	data, err := c.JSONBytes()
 	if err != nil {
 		return fmt.Errorf("error marshalling cursors: %w", err)
 	}
-	err = client.UploadBlob(ctx, storage.ForwarderContainer, BlobName, data)
+	err = client.UploadBlob(cursorSaveCtx, storage.ForwarderContainer, BlobName, data)
 	if err != nil {
 		return fmt.Errorf("uploading cursors failed: %w", err)
 	}

--- a/forwarder/internal/cursor/cursor.go
+++ b/forwarder/internal/cursor/cursor.go
@@ -66,19 +66,18 @@ func (c *Cursors) JSONBytes() ([]byte, error) {
 
 // Save saves the cursors to storage
 func (c *Cursors) Save(ctx context.Context, client *storage.Client) error {
-	cursorSaveCtx := ctx
 	if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
 		// Always save cursors - use a new context if error/timeout occurred already
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		cursorSaveCtx = timeoutCtx
+		ctx = timeoutCtx
 	}
 
 	data, err := c.JSONBytes()
 	if err != nil {
 		return fmt.Errorf("error marshalling cursors: %w", err)
 	}
-	err = client.UploadBlob(cursorSaveCtx, storage.ForwarderContainer, BlobName, data)
+	err = client.UploadBlob(ctx, storage.ForwarderContainer, BlobName, data)
 	if err != nil {
 		return fmt.Errorf("uploading cursors failed: %w", err)
 	}

--- a/forwarder/internal/cursor/cursor.go
+++ b/forwarder/internal/cursor/cursor.go
@@ -68,9 +68,9 @@ func (c *Cursors) JSONBytes() ([]byte, error) {
 func (c *Cursors) Save(ctx context.Context, client *storage.Client) error {
 	if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
 		// Always save cursors - use a new context if error/timeout occurred already
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cursorSaveCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		ctx = timeoutCtx
+		ctx = cursorSaveCtx
 	}
 
 	data, err := c.JSONBytes()


### PR DESCRIPTION
## Description
Enforce a 45s timeout in the forwarder to prevent overlapping executions

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-3242

This change affects:
 - [ ] Control Plane Tasks
 - [x] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
Unit test added and also manually tested by setting an artificially low timeout in the forwarder in my personal env:
<img width="2290" alt="image" src="https://github.com/user-attachments/assets/90bcc631-e325-456b-b94d-a610ea13735e" />


## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
