### PR TITLE
reduce scaling time

### DIFF
--- a/control_plane/tasks/scaling_task.py
+++ b/control_plane/tasks/scaling_task.py
@@ -52,7 +52,10 @@ DELETION_METRIC_PERIOD_MINUTES = 15
 METRIC_COLLECTION_PERIOD_MINUTES = DELETION_METRIC_PERIOD_MINUTES  # longer of the two periods^
 DEFAULT_SCALING_PERCENTAGE = 0.8
 
-SCALE_UP_EXECUTION_SECONDS = 45
+# max forwarder execution time before it times out is 45 seconds
+# use a lower time to ensure we have time to scale up
+SCALE_UP_EXECUTION_SECONDS = 40
+
 SCALE_DOWN_EXECUTION_SECONDS = 3
 
 MAX_FORWARDERS_PER_REGION = 15


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

This PR reduces the forwarder duration threshold for when to decide we need to scale up. The combined goal of this PR and the forwarder change was to ensure we are never seeing simultaneous runs of the forwarder

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
