### PR TITLE
bring back the app key

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,7 @@ build-tasks:
     refs:
       - main
   script:
+    - ci/scripts/control_plane/set_version.sh "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - ci/scripts/control_plane/build_tasks.sh
   artifacts:
     paths:

--- a/ci/scripts/deploy/deploy_qa_env.sh
+++ b/ci/scripts/deploy/deploy_qa_env.sh
@@ -12,6 +12,7 @@ AZURE_CLIENT_ID=$(vault kv get -field=azureClientId kv/k8s/gitlab-runner/azure-l
 AZURE_CLIENT_SECRET=$(vault kv get -field=azureSecret kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
 AZURE_SUBSCRIPTION_ID=$(vault kv get -field=subscriptionId kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
 DD_API_KEY=$(vault kv get -field=ddApiKey kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+DD_APP_KEY=$(vault kv get -field=ddAppKey kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
 
 # login to azure with app registration
 az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID"
@@ -25,4 +26,5 @@ az deployment mg create --management-group-id "Azure-Integrations-Mg" \
     --parameters monitoredSubscriptions="[\"$AZURE_SUBSCRIPTION_ID\"]" --parameters controlPlaneLocation=eastus \
     --parameters controlPlaneSubscriptionId="$AZURE_SUBSCRIPTION_ID" --parameters controlPlaneResourceGroupName=$resource_group \
     --parameters datadogApiKey="$DD_API_KEY" --parameters datadogSite=datadoghq.com --parameters datadogTelemetry=true \
+    --parameters datadogApplicationKey="$DD_APP_KEY" --parameters \
     --parameters imageRegistry=lfoqa.azurecr.io --parameters 'storageAccountUrl=https://lfoqa.blob.core.windows.net'

--- a/control_plane/scripts/initial_run.py
+++ b/control_plane/scripts/initial_run.py
@@ -82,10 +82,7 @@ async def run_tasks() -> None:
 
 async def main() -> None:
     try:
-        if await is_initial_deploy():
-            await run_tasks()
-        else:
-            print("This is a re-deploy, starting deployer instead")
+        await run_tasks()
     finally:
         await start_deployer()
 

--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -62,6 +62,7 @@ PII_RULES_JSON = (
 LOG_FORWARDER_CLIENT_SETTINGS: dict[str, str] = {
     "AzureWebJobsStorage": "connection-string",
     "DD_API_KEY": "123123",
+    "DD_APP_KEY": "456456",
     "DD_SITE": "datadoghq.com",
     "FORWARDER_IMAGE": "ddlfo.azurecr.io/blobforwarder:latest",
     "CONTROL_PLANE_REGION": EAST_US,

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -9,6 +9,9 @@ param controlPlaneResourceGroupName string
 @secure()
 @description('Datadog API Key')
 param datadogApiKey string
+@secure()
+@description('Datadog APP Key')
+param datadogApplicationKey string
 @description('Datadog Site')
 param datadogSite string
 @description('Comma separated list of tags to filter resources by')
@@ -69,6 +72,7 @@ module controlPlane './control_plane.bicep' = {
     controlPlaneSubscriptionId: controlPlaneSubscriptionId
     monitoredSubscriptions: monitoredSubscriptions
     datadogApiKey: datadogApiKey
+    datadogApplicationKey: datadogApplicationKey
     datadogSite: datadogSite
     datadogTelemetry: datadogTelemetry
     resourceTagFilters: resourceTagFilters

--- a/deploy/control_plane.bicep
+++ b/deploy/control_plane.bicep
@@ -12,6 +12,8 @@ param storageAccountUrl string
 
 @secure()
 param datadogApiKey string
+@secure()
+param datadogAppKey string
 param datadogSite string
 param piiScrubberRules string
 param resourceTagFilters string
@@ -25,6 +27,7 @@ var forwarderImage = '${imageRegistry}/forwarder:latest'
 var STORAGE_CONNECTION_SETTING = 'AzureWebJobsStorage'
 var DD_SITE_SETTING = 'DD_SITE'
 var DD_API_KEY_SETTING = 'DD_API_KEY'
+var DD_APP_KEY_SETTING = 'DD_APP_KEY'
 var DD_TELEMETRY_SETTING = 'DD_TELEMETRY'
 var FORWARDER_IMAGE_SETTING = 'FORWARDER_IMAGE'
 var SUBSCRIPTION_ID_SETTING = 'SUBSCRIPTION_ID'
@@ -39,6 +42,7 @@ var LOG_LEVEL_SETTING = 'LOG_LEVEL'
 
 // Secret Names
 var DD_API_KEY_SECRET = 'dd-api-key'
+var DD_APP_KEY_SECRET = 'dd-app-key'
 var CONNECTION_STRING_SECRET = 'connection-string'
 
 // CONTROL PLANE RESOURCES
@@ -199,6 +203,7 @@ resource deployerTask 'Microsoft.App/jobs@2024-03-01' = {
       secrets: [
         { name: CONNECTION_STRING_SECRET, value: connectionString }
         { name: DD_API_KEY_SECRET, value: datadogApiKey }
+        { name: DD_APP_KEY_SECRET, value: datadogApplicationKey }
       ]
     }
     template: {
@@ -217,6 +222,7 @@ resource deployerTask 'Microsoft.App/jobs@2024-03-01' = {
             { name: CONTROL_PLANE_ID_SETTING, value: controlPlaneId }
             { name: CONTROL_PLANE_REGION_SETTING, value: controlPlaneLocation }
             { name: DD_API_KEY_SETTING, secretRef: DD_API_KEY_SECRET }
+            { name: DD_APP_KEY_SECRET, value: datadogApplicationKey }
             { name: DD_SITE_SETTING, value: datadogSite }
             { name: DD_TELEMETRY_SETTING, value: datadogTelemetry ? 'true' : 'false' }
             { name: STORAGE_ACCOUNT_URL_SETTING, value: storageAccountUrl }

--- a/deploy/createUiDefinition.json
+++ b/deploy/createUiDefinition.json
@@ -90,7 +90,7 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "To fill out the fields below, copy the API key from your Datadog org. You can find your API Key in the Access section of the Organization Settings.",
+                  "text": "To fill out the fields below, copy the API and Application keys from your Datadog org. You can find your API and App keys in the Access section of the Organization Settings.",
                   "link": {
                     "label": "Learn more",
                     "uri": "https://docs.datadoghq.com/account_management/org_settings/"
@@ -109,6 +109,24 @@
                   "required": true,
                   "regex": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$).*",
                   "validationMessage": "Must be a valid API Key (not a Key ID)."
+                },
+                "options": {
+                  "hideConfirmation": true
+                },
+                "visible": true
+              },
+              {
+                "name": "datadogApplicationKey",
+                "type": "Microsoft.Common.PasswordBox",
+                "label": {
+                  "password": "Datadog Application Key",
+                  "confirmPassword": "Re-enter Datadog Application Key"
+                },
+                "toolTip": "Your Datadog Application key",
+                "constraints": {
+                  "required": true,
+                  "regex": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$).*",
+                  "validationMessage": "Must be a valid Application Key (not a Key ID)."
                 },
                 "options": {
                   "hideConfirmation": true
@@ -253,6 +271,7 @@
       "controlPlaneSubscriptionId": "[steps('basics').controlPlaneSubscription]",
       "controlPlaneResourceGroupName": "[steps('basics').resourceGroup]",
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
+      "datadogApplicationKey": "[steps('datadogConfig').datadogIntegration.datadogApplicationKey]",
       "datadogSite": "[steps('datadogConfig').datadogIntegration.datadogSite]",
       "resourceTagFilters": "[steps('datadogConfig').tagFiltering.resourceTagFilters]",
       "piiScrubberRules": "[steps('datadogConfig').logsPiiFiltering.piiFilterConfigs]"

--- a/scripts/deploy_personal_env.py
+++ b/scripts/deploy_personal_env.py
@@ -199,12 +199,15 @@ if initial_deploy or FORCE_ARM_DEPLOY:
         + f"https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id/%2Fproviders%2FMicrosoft.Management%2FmanagementGroups%2FAzure-Integrations-Mg%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2F{quote(resource_group_name, safe='')}"
     )
     api_key = environ["DD_API_KEY"]
+    app_key = environ["DD_APP_KEY"]
+
     params = {
         "monitoredSubscriptions": dumps([subscription_id]),
         "controlPlaneLocation": LOCATION,
         "controlPlaneSubscriptionId": subscription_id,
         "controlPlaneResourceGroupName": resource_group_name,
         "datadogApiKey": api_key,
+        "datadogApplicationKey": app_key,
         "datadogTelemetry": "true",
         "piiScrubberRules": environ.get("PII_SCRUBBER_RULES", ""),
         "resourceTagFilters": environ.get("RESOURCE_TAG_FILTERS", ""),

--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -35,6 +35,9 @@ export STORAGE_ACCOUNT_URL='https://ddazurelfo.blob.core.windows.net'
 if [ -z "${DD_API_KEY+x}" ]; then
     export DD_API_KEY="not_a_real_key"
 fi
+if [ -z "${DD_APP_KEY+x}" ]; then
+    export DD_APP_KEY="not_a_real_key"
+fi
 if [ -z "${DD_SITE+x}" ]; then
     export DD_SITE="datadoghq.com"
 fi


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue:

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
