### PR TITLE
fix deployer args

### DIFF
--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -62,7 +62,7 @@ def get_azure_mgmt_url(region: str) -> str:
 class DeployerTask(Task):
     NAME = DEPLOYER_TASK_NAME
 
-    def __init__(self, is_initial_run: False) -> None:
+    def __init__(self, is_initial_run: bool = False) -> None:
         super().__init__()
         self.subscription_id = get_config_option(SUBSCRIPTION_ID_SETTING)
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -62,7 +62,7 @@ def get_azure_mgmt_url(region: str) -> str:
 class DeployerTask(Task):
     NAME = DEPLOYER_TASK_NAME
 
-    def __init__(self) -> None:
+    def __init__(self, is_initial_run: False) -> None:
         super().__init__()
         self.subscription_id = get_config_option(SUBSCRIPTION_ID_SETTING)
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -68,7 +68,7 @@ class TestDeployerTask(TaskTestCase):
         )
 
     async def run_deployer_task(self) -> DeployerTask:
-        async with DeployerTask() as task:
+        async with DeployerTask(is_initial_run=False) as task:
             await task.run()
         return task
 


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Please is failing in production due to missing an argument. Can see this in the logs for the deployer in lfoprodenv
https://portal.azure.com/#view/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/timespanInIsoFormat/P1Y/resourceId/%2Fsubscriptions%2F0b62a232-b8db-4380-9da6-640f7272ed6d%2FresourceGroups%2Flfoprodenv%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2Flogs/source/WebsitesExtension.ContainerAppJobsExecutionHistoryGrid/query/ContainerAppConsoleLogs_CL%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20where%20ContainerGroupName_s%20startswith%20'deployer-task-72353642a160-29152470'

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
