### PR TITLE
update terraform example configuration to match Scaling Task

### DIFF
--- a/deploy/terraform/standalone/terraform.tfvars.example
+++ b/deploy/terraform/standalone/terraform.tfvars.example
@@ -6,14 +6,14 @@ datadog_api_key     = "your-32-character-datadog-api-key"
 location                      = "East US"
 environment_name              = "datadog-log-forwarder-env"
 job_name                      = "datadog-log-forwarder"
-storage_account_name          = "spurlog20250606storage"  # Must be globally unique
+storage_account_name          = "datadogLogStorage"  # Must be globally unique
 storage_account_sku           = "Standard_LRS"
 storage_account_retention_days = 7
 datadog_site                  = "datadoghq.com"
 forwarder_image               = "datadoghq.azurecr.io/forwarder:latest"
-forwarder_cpu                 = 1
-forwarder_memory              = "2Gi"
-schedule_expression           = "*/5 * * * *"  # Run every 5 minutes
+forwarder_cpu                 = 2
+forwarder_memory              = "4Gi"
+schedule_expression           = "* * * * *"  # Run every minute
 
 # Tags
 tags = {


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Updates our example terraform configuration to match what we deploy in the scaling task.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
