### PR TITLE
[CODEX-1454] migrating to the 22.04 based pr-commenter image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  PR_COMMENTER_IMAGE: registry.ddbuild.io/images/pr-commenter:3
+  PR_COMMENTER_IMAGE: registry.ddbuild.io/images/pr-commenter:3-jammy
   DOCKER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
   CI_IMAGE: registry.ddbuild.io/ci/azure-log-forwarding-orchestration-ci:latest
   REPLICATED_DOCKER_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com/lfo


### PR DESCRIPTION
Ubuntu 20.04 is EOL and a new pr-commenter image is available