### PR TITLE
add support for vnet flow logs

### DIFF
--- a/forwarder/internal/logs/client.go
+++ b/forwarder/internal/logs/client.go
@@ -35,7 +35,6 @@ const (
 	newlineBytes = 1
 
 	functionAppContainer = "insights-logs-functionapplogs"
-	flowEventContainer   = "insights-logs-networksecuritygroupflowevent"
 )
 
 // Client is a client for submitting logs to Datadog.

--- a/forwarder/internal/logs/parse.go
+++ b/forwarder/internal/logs/parse.go
@@ -76,9 +76,14 @@ func (f FlowEventParser) Parse(scanner *bufio.Scanner, blob storage.Blob, piiScr
 	}
 }
 
+var flowEventContainers = []string{
+	"insights-logs-flowlogflowevent",
+	"insights-logs-networksecuritygroupflowevent",
+}
+
 // Valid checks if the blob is in a flow event container.
 func (f FlowEventParser) Valid(blob storage.Blob) bool {
-	return blob.Container.Name == flowEventContainer
+	return slices.Contains(flowEventContainers, blob.Container.Name)
 }
 
 type FunctionAppParser struct{}
@@ -125,7 +130,7 @@ func (f FunctionAppParser) Valid(blob storage.Blob) bool {
 
 type ActiveDirectoryParser struct{}
 
-// TODO for commented containers: https://datadoghq.atlassian.net/browse/AZINTS-3430
+// TODO Commented containers need additional testing: https://datadoghq.atlassian.net/browse/AZINTS-3430
 var activeDirectoryContainers = []string{
 	"insights-logs-auditlogs",
 	"insights-logs-signinlogs",


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Previously we added support for NSG Flow Logs. vnet flow logs go to a different container. This PR adds that container to our list of containers to check against

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
