### PR TITLE
feat(forwarder): add support for uami

### DIFF
--- a/deploy/terraform/standalone/forwarder.tf
+++ b/deploy/terraform/standalone/forwarder.tf
@@ -267,6 +267,15 @@ resource "azurerm_container_app_job" "forwarder" {
   tags = var.tags
 }
 
+# RBAC Role Assignments
+resource "azurerm_role_assignment" "forwarder_storage_access" {
+  scope                = azurerm_storage_account.forwarder_storage.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.user_assigned_identity_principal_id
+
+  depends_on = [azurerm_container_app_job.forwarder]
+}
+
 # Outputs
 output "storage_account_name" {
   description = "Name of the created storage account"

--- a/deploy/terraform/standalone/forwarder.tf
+++ b/deploy/terraform/standalone/forwarder.tf
@@ -61,6 +61,14 @@ variable "storage_account_retention_days" {
   }
 }
 
+variable "user_assigned_identity_client_id" {
+  description = <<-EOT
+    Client ID of the User-Assigned Managed Identity.
+    Used by Azure SDK to identify which managed identity to use for authentication.
+  EOT
+  type        = string
+}
+
 variable "datadog_api_key" {
   description = "Datadog API Key"
   type        = string
@@ -218,6 +226,14 @@ resource "azurerm_container_app_job" "forwarder" {
       env {
         name        = "AzureWebJobsStorage"
         secret_name = "storage-connection-string"
+      }
+      env {
+        name  = "AzureWebJobsStorage__accountUrl"
+        value = "https://${azurerm_storage_account.forwarder_storage.name}.blob.core.windows.net/"
+      }
+      env {
+        name  = "AZURE_CLIENT_ID"
+        value = var.user_assigned_identity_client_id
       }
       env {
         name        = "DD_API_KEY"

--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	// 3p
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -406,10 +407,53 @@ func main() {
 	}
 
 	// Initialize storage client
+	// Support both managed identity and connection string authentication
+	var azBlobClient *azblob.Client
+	storageAccountURL := environment.Get(environment.AzureWebJobsStorageAccountURL)
 	storageAccountConnectionString := environment.Get(environment.AzureWebJobsStorage)
-	azBlobClient, err := azblob.NewClientFromConnectionString(storageAccountConnectionString, nil)
-	if err != nil {
-		logger.Fatal(fmt.Errorf("error creating azure blob client: %w", err).Error())
+
+	if storageAccountURL != "" {
+		// Use managed identity authentication (preferred)
+		logger.Info("Using managed identity authentication for Azure Storage")
+
+		clientID := environment.Get(environment.AzureClientID)
+
+		if clientID != "" {
+			// Use user-assigned managed identity
+			logger.Info(fmt.Sprintf("Using user-assigned managed identity with client ID: %s", clientID))
+			opts := &azidentity.ManagedIdentityCredentialOptions{
+				ID: azidentity.ClientID(clientID),
+			}
+			cred, credErr := azidentity.NewManagedIdentityCredential(opts)
+			if credErr != nil {
+				logger.Fatal(fmt.Errorf("error creating user-assigned managed identity credential: %w", credErr).Error())
+				return
+			}
+			azBlobClient, err = azblob.NewClient(storageAccountURL, cred, nil)
+		} else {
+			// Use system-assigned managed identity or other default credential chain
+			logger.Info("Using default Azure credential chain (system-assigned MI or other)")
+			cred, credErr := azidentity.NewDefaultAzureCredential(nil)
+			if credErr != nil {
+				logger.Fatal(fmt.Errorf("error creating Azure credential: %w", credErr).Error())
+				return
+			}
+			azBlobClient, err = azblob.NewClient(storageAccountURL, cred, nil)
+		}
+		if err != nil {
+			logger.Fatal(fmt.Errorf("error creating azure blob client with managed identity: %w", err).Error())
+			return
+		}
+	} else if storageAccountConnectionString != "" {
+		// Fallback to connection string authentication (legacy)
+		logger.Warning("Using connection string authentication for Azure Storage (consider migrating to managed identity)")
+		azBlobClient, err = azblob.NewClientFromConnectionString(storageAccountConnectionString, nil)
+		if err != nil {
+			logger.Fatal(fmt.Errorf("error creating azure blob client: %w", err).Error())
+			return
+		}
+	} else {
+		logger.Fatal("error: neither AzureWebJobsStorage__accountUrl nor AzureWebJobsStorage environment variables are set")
 		return
 	}
 

--- a/forwarder/go.mod
+++ b/forwarder/go.mod
@@ -5,6 +5,7 @@ go 1.25.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
 	github.com/DataDog/datadog-api-client-go/v2 v2.42.0
 	github.com/docker/go-connections v0.5.0
@@ -21,6 +22,7 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.3.2 // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
@@ -39,7 +41,9 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -51,6 +55,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/forwarder/go.sum
+++ b/forwarder/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1 h1:DSDNVxqkoXJiko6x8a90zido
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1/go.mod h1:zGqV2R4Cr/k8Uye5w+dgQ06WJtEcbQG/8J7BB6hnCr4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0 h1:B/dfvscEQtew9dVuoxqxrUKKv8Ih2f55PydknDamU+g=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0/go.mod h1:fiPSssYvltE08HJchL04dOy+RD4hgrjph0cwGGMntdI=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.0 h1:+m0M/LFxN43KvULkDNfdXOgrjtg6UYJPFBJyuEcRCAw=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.0/go.mod h1:PwOyop78lveYMRs6oCxjiVyBdyCgIYH6XHIVZO9/SFQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0 h1:PiSrjRPpkQNjrM8H0WwKMnZUdu1RGMtd/LdGKUrOo+c=
@@ -14,6 +16,8 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0 h1:UXT0o77lXQrikd1kg
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0/go.mod h1:cTvi54pg19DoT07ekoeMgE/taAwNtCShVeZqA+Iv2xI=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
+github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.3.2 h1:kYRSnvJju5gYVyhkij+RTJ/VR6QIUaCfWeaFm2ycsjQ=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.3.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/DataDog/datadog-api-client-go/v2 v2.42.0 h1:0L03LqChbOf7IaaiBUZpXi1Ss6PseGGhQEQrNqD9nU8=
@@ -24,6 +28,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
@@ -36,6 +42,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.0.1+incompatible h1:FCHjSRdXhNRFjlHMTv4jUNlIBbTeRjrWfeFuJp7jpo0=
@@ -72,6 +80,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 h1:VNqngBF40hVlDloBruUehVYC3ArSgIyScOAyMRqBxRg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1/go.mod h1:RBRO7fro65R6tjKzYgLAFo0t1QEXY1Dp+i/bvpRiqiQ=
+github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKuao2vNdfD82fjjgPLfyHLpR41Z88viRWs=
+github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
@@ -113,6 +123,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
+github.com/redis/go-redis/v9 v9.6.1/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
@@ -182,6 +194,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=

--- a/forwarder/internal/environment/variables.go
+++ b/forwarder/internal/environment/variables.go
@@ -10,17 +10,19 @@ import (
 
 // Environment variable names
 const (
-	ApmEnabled          = "DD_APM_ENABLED"
-	AzureWebJobsStorage = "AzureWebJobsStorage"
-	ControlPlaneId      = "CONTROL_PLANE_ID"
-	ConfigId            = "CONFIG_ID"
-	DdApiKey            = "DD_API_KEY"
-	ForceProfile        = "DD_FORCE_PROFILE"
-	DdSite              = "DD_SITE"
-	TelemetryEnabled    = "DD_TELEMETRY"
-	NumGoroutines       = "NUM_GOROUTINES"
-	PiiScrubberRules    = "PII_SCRUBBER_RULES"
-	VersionTag          = "VERSION_TAG"
+	ApmEnabled                    = "DD_APM_ENABLED"
+	AzureWebJobsStorage           = "AzureWebJobsStorage"
+	AzureWebJobsStorageAccountURL = "AzureWebJobsStorage__accountUrl"
+	AzureClientID                 = "AZURE_CLIENT_ID"
+	ControlPlaneId                = "CONTROL_PLANE_ID"
+	ConfigId                      = "CONFIG_ID"
+	DdApiKey                      = "DD_API_KEY"
+	ForceProfile                  = "DD_FORCE_PROFILE"
+	DdSite                        = "DD_SITE"
+	TelemetryEnabled              = "DD_TELEMETRY"
+	NumGoroutines                 = "NUM_GOROUTINES"
+	PiiScrubberRules              = "PII_SCRUBBER_RULES"
+	VersionTag                    = "VERSION_TAG"
 )
 
 func Get(envVar string) string {


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Add a new feature to support User Assigned Managed Identity for the forwarders, instead of relying on Storage Account Access Keys. 

User will need to pass in two values in the Terraform:
* `AzureWebJobsStorage__accountUrl`: URL to the storage account
* `AZURE_CLIENT_ID`: Client Id of the UAMI

This change affects:
 - [ ] Control Plane Tasks
 - [X] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

```
# ==========================================
# Container App Job
# ==========================================

resource "azurerm_container_app_job" "forwarder" {
    ...
  template {
    container {
      ...
      env {
        name  = "AzureWebJobsStorage__accountUrl"
        value = "https://${azurerm_storage_account.forwarder_storage.name}.blob.core.windows.net/"
      }
      env {
        name  = "AZURE_CLIENT_ID"
        value = var.user_assigned_identity_client_id
      }
     ...
    }
  }

```

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
