### PR TITLE
Update WEBSITE_CONTENTSHARE and use async zip deploys

### DIFF
--- a/control_plane/cache/manifest_cache.py
+++ b/control_plane/cache/manifest_cache.py
@@ -3,7 +3,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
 
 # stdlib
-from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
 
 # project
@@ -44,43 +43,6 @@ KEY_TO_ZIP: dict[ControlPlaneComponent, str] = {
 
 ALL_ZIPS = frozenset(KEY_TO_ZIP.values())
 ALL_COMPONENTS = frozenset(KEY_TO_ZIP)
-
-
-PENDING_DEPLOYMENTS_CACHE_NAME = "pending_deployments.json"
-
-
-@dataclass
-class PendingDeployment:
-    component: ControlPlaneComponent
-    function_app: str
-    poll_url: str
-    target_manifest_hash: str
-
-
-PendingDeploymentsCache: TypeAlias = dict[ControlPlaneComponent, PendingDeployment]
-
-PENDING_DEPLOYMENT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "propertyNames": {"enum": ["resources", "scaling", "diagnostic_settings"]},
-    "additionalProperties": {
-        "type": "object",
-        "properties": {
-            "component": {"type": "string"},
-            "function_app": {"type": "string"},
-            "poll_url": {"type": "string"},
-            "target_manifest_hash": {"type": "string"},
-        },
-        "required": ["component", "function_app", "poll_url", "target_manifest_hash"],
-        "additionalProperties": False,
-    },
-}
-
-
-def deserialize_pending_deployments(raw: str) -> PendingDeploymentsCache:
-    result = deserialize_cache(raw, PENDING_DEPLOYMENT_SCHEMA)
-    if not result:
-        return {}
-    return {k: PendingDeployment(**v) for k, v in result.items()}
 
 
 def prune_manifest_cache(manifest_cache: ManifestCache) -> ManifestCache:

--- a/control_plane/cache/manifest_cache.py
+++ b/control_plane/cache/manifest_cache.py
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
 
 # stdlib
+from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
 
 # project
@@ -13,7 +14,16 @@ ManifestCache: TypeAlias = dict[ControlPlaneComponent, str]
 """Mapping of deployable name to SHA-256 manifest"""
 
 
-MANIFEST_SCHEMA: dict[str, Any] = {
+@dataclass
+class ComponentState:
+    version: str
+    deployment_url: str = ""
+
+
+PrivateManifestCache: TypeAlias = dict[ControlPlaneComponent, ComponentState]
+
+
+PUBLIC_MANIFEST_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "resources": {"type": "string"},
@@ -50,5 +60,27 @@ def prune_manifest_cache(manifest_cache: ManifestCache) -> ManifestCache:
     return {component: manifest_cache[component] for component in ALL_COMPONENTS if component in manifest_cache}
 
 
-def deserialize_manifest_cache(raw_manifest_cache: str) -> ManifestCache | None:
-    return deserialize_cache(raw_manifest_cache, MANIFEST_SCHEMA, prune_manifest_cache)
+def deserialize_public_manifest_cache(raw_manifest_cache: str) -> ManifestCache | None:
+    return deserialize_cache(raw_manifest_cache, PUBLIC_MANIFEST_SCHEMA, prune_manifest_cache)
+
+
+PRIVATE_MANIFEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "propertyNames": {"enum": ["resources", "scaling", "diagnostic_settings"]},
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "version": {"type": "string"},
+            "deployment_url": {"type": "string"},
+        },
+        "required": ["version"],
+        "additionalProperties": False,
+    },
+}
+
+
+def deserialize_private_manifest_cache(raw: str) -> PrivateManifestCache | None:
+    result: dict[str, Any] | None = deserialize_cache(raw, PRIVATE_MANIFEST_SCHEMA)
+    if not result:
+        return None
+    return {k: ComponentState(**v) for k, v in result.items()}

--- a/control_plane/cache/manifest_cache.py
+++ b/control_plane/cache/manifest_cache.py
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
 
 # stdlib
+from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
 
 # project
@@ -43,6 +44,43 @@ KEY_TO_ZIP: dict[ControlPlaneComponent, str] = {
 
 ALL_ZIPS = frozenset(KEY_TO_ZIP.values())
 ALL_COMPONENTS = frozenset(KEY_TO_ZIP)
+
+
+PENDING_DEPLOYMENTS_CACHE_NAME = "pending_deployments.json"
+
+
+@dataclass
+class PendingDeployment:
+    component: ControlPlaneComponent
+    function_app: str
+    poll_url: str
+    target_manifest_hash: str
+
+
+PendingDeploymentsCache: TypeAlias = dict[ControlPlaneComponent, PendingDeployment]
+
+PENDING_DEPLOYMENT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "propertyNames": {"enum": ["resources", "scaling", "diagnostic_settings"]},
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "component": {"type": "string"},
+            "function_app": {"type": "string"},
+            "poll_url": {"type": "string"},
+            "target_manifest_hash": {"type": "string"},
+        },
+        "required": ["component", "function_app", "poll_url", "target_manifest_hash"],
+        "additionalProperties": False,
+    },
+}
+
+
+def deserialize_pending_deployments(raw: str) -> PendingDeploymentsCache:
+    result = deserialize_cache(raw, PENDING_DEPLOYMENT_SCHEMA)
+    if not result:
+        return {}
+    return {k: PendingDeployment(**v) for k, v in result.items()}
 
 
 def prune_manifest_cache(manifest_cache: ManifestCache) -> ManifestCache:

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -157,12 +157,44 @@ class DeployerTask(Task):
             )
         }
 
+    async def fix_content_share(self, function_app_name: str) -> bool:
+        settings = await self.web_client.web_apps.list_application_settings(
+            self.resource_group, function_app_name
+        )
+        correct_value = f"contentshare-{function_app_name}"
+        properties = settings.properties or {}
+        if properties.get("WEBSITE_CONTENTSHARE") == correct_value:
+            return False
+        self.log.info(
+            "Fixing WEBSITE_CONTENTSHARE for %s (was: %s)",
+            function_app_name,
+            properties.get("WEBSITE_CONTENTSHARE"),
+        )
+        if settings.properties is None:
+            settings.properties = {}
+        settings.properties["WEBSITE_CONTENTSHARE"] = correct_value
+        await self.web_client.web_apps.update_application_settings(
+            self.resource_group, function_app_name, settings
+        )
+        return True
+
     async def deploy_component(self, component: ControlPlaneComponent, current_function_app_ids: set[str]) -> None:
         task_prefix = f"{component.replace('_', '-')}-task-"
         function_app = next((app for app in current_function_app_ids if app.startswith(task_prefix)), None)
         if not function_app:
             self.log.error(f"Function app for {component} not found in {current_function_app_ids}, skipping deployment")
             return
+
+        try:
+            content_share_fixed = await self.fix_content_share(function_app)
+        except Exception:
+            self.log.exception("Failed to check/fix content share for %s", function_app)
+            return
+
+        if content_share_fixed:
+            self.log.info("Content share fixed for %s, skipping deployment this run", function_app)
+            return
+
         try:
             self.log.info(f"Downloading function app data for {component}")
             zip_data = await self.download_function_app_data(component)

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -157,22 +157,27 @@ class DeployerTask(Task):
             )
         }
 
-    async def fix_content_share(self, function_app_name: str) -> bool:
+    async def fix_content_share(self, function_app_name: str, resources_task_name: str) -> bool:
         settings = await self.web_client.web_apps.list_application_settings(
             self.resource_group, function_app_name
         )
-        correct_value = f"contentshare-{function_app_name}"
         properties = settings.properties or {}
-        if properties.get("WEBSITE_CONTENTSHARE") == correct_value:
+        
+        current_value = properties.get("WEBSITE_CONTENTSHARE")
+        if current_value != resources_task_name:
+            # Variable has already been updated or was created via the python deployment script
             return False
+
+        new_value = f"contentshare-{function_app_name}"
         self.log.info(
-            "Fixing WEBSITE_CONTENTSHARE for %s (was: %s)",
+            "Fixing WEBSITE_CONTENTSHARE for %s (was: %s, now: %s)",
             function_app_name,
             properties.get("WEBSITE_CONTENTSHARE"),
+            new_value,
         )
         if settings.properties is None:
             settings.properties = {}
-        settings.properties["WEBSITE_CONTENTSHARE"] = correct_value
+        settings.properties["WEBSITE_CONTENTSHARE"] = new_value
         await self.web_client.web_apps.update_application_settings(
             self.resource_group, function_app_name, settings
         )
@@ -185,8 +190,9 @@ class DeployerTask(Task):
             self.log.error(f"Function app for {component} not found in {current_function_app_ids}, skipping deployment")
             return
 
+        resources_task = next((app for app in current_function_app_ids if app.startswith(RESOURCES_TASK_PREFIX)), None)
         try:
-            content_share_fixed = await self.fix_content_share(function_app)
+            content_share_fixed = await self.fix_content_share(function_app, resources_task or "")
         except Exception:
             self.log.exception("Failed to check/fix content share for %s", function_app)
             return

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -4,6 +4,7 @@
 
 # stdlib
 from asyncio import gather, run
+from dataclasses import asdict
 from json import dumps
 from os import environ
 from types import TracebackType
@@ -28,11 +29,15 @@ from cache.env import (
 from cache.manifest_cache import (
     KEY_TO_ZIP,
     MANIFEST_FILE_NAME,
+    PENDING_DEPLOYMENTS_CACHE_NAME,
     PUBLIC_STORAGE_ACCOUNT_URL,
     TASKS_CONTAINER,
     ControlPlaneComponent,
     ManifestCache,
+    PendingDeployment,
+    PendingDeploymentsCache,
     deserialize_manifest_cache,
+    deserialize_pending_deployments,
 )
 from tasks.common import (
     DIAGNOSTIC_SETTINGS_TASK_PREFIX,
@@ -45,6 +50,10 @@ from tasks.concurrency import collect
 from tasks.task import Task, task_main
 
 DEPLOYER_TASK_NAME = "deployer_task"
+
+KUDU_STATUSES_IN_PROGRESS = {0, 1, 2}
+KUDU_STATUS_FAILED = 3
+KUDU_STATUS_SUCCESS = 4
 
 
 MAX_ATTEMPTS = 5
@@ -62,8 +71,10 @@ def get_azure_mgmt_url(region: str) -> str:
 class DeployerTask(Task):
     NAME = DEPLOYER_TASK_NAME
 
-    def __init__(self, is_initial_run: bool = False) -> None:
-        super().__init__()
+    def __init__(self, pending_deployments_state: str = "", is_initial_run: bool = False) -> None:
+        super().__init__(is_initial_run=is_initial_run)
+        self.pending_deployments: PendingDeploymentsCache = deserialize_pending_deployments(pending_deployments_state)
+        self._initial_pending_deployments: PendingDeploymentsCache = dict(self.pending_deployments)
         self.subscription_id = get_config_option(SUBSCRIPTION_ID_SETTING)
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)
         self.region = get_config_option(CONTROL_PLANE_REGION_SETTING)
@@ -190,6 +201,10 @@ class DeployerTask(Task):
             self.log.error(f"Function app for {component} not found in {current_function_app_ids}, skipping deployment")
             return
 
+        if pending := self.pending_deployments.get(component):
+            await self._check_pending_deployment(component, pending)
+            return
+
         resources_task = next((app for app in current_function_app_ids if app.startswith(RESOURCES_TASK_PREFIX)), None)
         try:
             content_share_fixed = await self.fix_content_share(function_app, resources_task or "")
@@ -201,27 +216,75 @@ class DeployerTask(Task):
             self.log.info("Content share fixed for %s, skipping deployment this run", function_app)
             return
 
-        try:
-            self.log.info(f"Downloading function app data for {component}")
-            zip_data = await self.download_function_app_data(component)
-            self.log.info(f"Deploying {function_app}")
-            await self.upload_function_app_data(function_app, zip_data)
-            await self.sync_function_app_triggers(function_app)
-        except Exception as e:
-            self.log.exception(f"Failed to deploy {component}: {e}")
-            return
-        self.manifest_cache[component] = self.public_manifest[component]
-        self.log.info(f"Finished deploying {component}")
+        await self._start_deployment(component, function_app)
 
-    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:
+    async def _start_deployment(self, component: ControlPlaneComponent, function_app: str) -> None:
+        try:
+            zip_data = await self.download_function_app_data(component)
+            poll_url = await self.upload_function_app_data(function_app, zip_data)
+        except Exception as e:
+            self.log.exception("Failed to start deployment for %s: %s", component, e)
+            return
+        self.pending_deployments[component] = PendingDeployment(
+            component=component,
+            function_app=function_app,
+            poll_url=poll_url,
+            target_manifest_hash=self.public_manifest[component],
+        )
+        self.log.info("Async deploy started for %s, will poll on next run", function_app)
+
+    async def _check_pending_deployment(self, component: ControlPlaneComponent, pending: PendingDeployment) -> None:
+        try:
+            is_complete, is_successful = await self.check_deployment_status(pending.poll_url)
+        except Exception:
+            self.log.exception("Failed to check deployment status for %s", component)
+            return
+
+        if not is_complete:
+            self.log.info("Deployment still in progress for %s", component)
+            return
+
+        del self.pending_deployments[component]
+
+        if not is_successful:
+            self.log.error("Deployment failed for %s, will retry next run", component)
+            return
+
+        try:
+            await self.sync_function_app_triggers(pending.function_app)
+        except Exception as e:
+            self.log.exception("Failed to sync triggers for %s: %s", component, e)
+            return
+
+        self.manifest_cache[component] = pending.target_manifest_hash
+        self.log.info("Finished deploying %s", component)
+
+    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> str:
         # Don't retry the zip deploy to avoid starting multiple deployments
-        function_app_url = "https://{}.scm.azurewebsites.{}/api/zipdeploy".format(
+        function_app_url = "https://{}.scm.azurewebsites.{}/api/zipdeploy?isAsync=true".format(
             function_app_name, "us" if is_azure_gov(self.region) else "net"
         )
         resp = await self.rest_client.post(function_app_url, data=function_app_data)
+        if resp.status != 202:
+            content = (await resp.content.read()).decode()
+            raise DeployError(f"Failed to start async zip deploy: expected 202, got {resp.status} ({resp.reason})\n{content}")
+        poll_url = resp.headers.get("Location")
+        if not poll_url:
+            raise DeployError("Async zip deploy returned 202 but no Location header")
+        return poll_url
+
+    async def check_deployment_status(self, poll_url: str) -> tuple[bool, bool]:
+        """Returns (is_complete, is_successful). Raises DeployError on HTTP error."""
+        resp = await self.rest_client.get(poll_url)
         if not resp.ok:
             content = (await resp.content.read()).decode()
-            raise DeployError(f"Failed to upload function app data: {resp.status} ({resp.reason})\n{content}")
+            raise DeployError(f"Failed to poll deployment status: {resp.status} ({resp.reason})\n{content}")
+        body = await resp.json()
+        status: int = body.get("status", 0)
+        KUDU_STATUS_SUCCESS = 4
+        if status in KUDU_STATUSES_IN_PROGRESS:
+            return False, False
+        return True, status == KUDU_STATUS_SUCCESS
 
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
     async def sync_function_app_triggers(self, function_app_name: str) -> None:
@@ -240,10 +303,16 @@ class DeployerTask(Task):
         return app_data
 
     async def write_caches(self) -> None:
-        if self.manifest_cache == self.private_manifest:
-            return
-        await write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache))
+        writes = []
+        if self.manifest_cache != self.private_manifest:
+            writes.append(write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache)))
+        pending_dict = {c: asdict(p) for c, p in self.pending_deployments.items()}
+        initial_dict = {c: asdict(p) for c, p in self._initial_pending_deployments.items()}
+        if pending_dict != initial_dict:
+            writes.append(write_cache(PENDING_DEPLOYMENTS_CACHE_NAME, dumps(pending_dict)))
+        if writes:
+            await gather(*writes)
 
 
 if __name__ == "__main__":
-    run(task_main(DeployerTask, []))
+    run(task_main(DeployerTask, [PENDING_DEPLOYMENTS_CACHE_NAME]))

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -164,7 +164,6 @@ class DeployerTask(Task):
         correct_value = f"contentshare-{function_app_name}"
         properties = settings.properties or {}
         if properties.get("WEBSITE_CONTENTSHARE") == correct_value:
-            self.log.info("Content share already correct for %s", function_app_name)
             return False
         self.log.info(
             "Fixing WEBSITE_CONTENTSHARE for %s (was: %s)",
@@ -187,22 +186,26 @@ class DeployerTask(Task):
             return
 
         try:
-            await self.fix_content_share(function_app)
+            content_share_fixed = await self.fix_content_share(function_app)
         except Exception:
             self.log.exception("Failed to check/fix content share for %s", function_app)
             return
 
-        # try:
-        #     self.log.info(f"Downloading function app data for {component}")
-        #     zip_data = await self.download_function_app_data(component)
-        #     self.log.info(f"Deploying {function_app}")
-        #     await self.upload_function_app_data(function_app, zip_data)
-        #     await self.sync_function_app_triggers(function_app)
-        # except Exception:
-        #     self.log.exception(f"Failed to deploy {component}")
-        #     return
-        # self.manifest_cache[component] = self.public_manifest[component]
-        # self.log.info(f"Finished deploying {component}")
+        if content_share_fixed:
+            self.log.info("Content share fixed for %s, skipping deployment this run", function_app)
+            return
+
+        try:
+            self.log.info(f"Downloading function app data for {component}")
+            zip_data = await self.download_function_app_data(component)
+            self.log.info(f"Deploying {function_app}")
+            await self.upload_function_app_data(function_app, zip_data)
+            await self.sync_function_app_triggers(function_app)
+        except Exception:
+            self.log.exception(f"Failed to deploy {component}")
+            return
+        self.manifest_cache[component] = self.public_manifest[component]
+        self.log.info(f"Finished deploying {component}")
 
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
     async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -207,14 +207,14 @@ class DeployerTask(Task):
             self.log.info(f"Deploying {function_app}")
             await self.upload_function_app_data(function_app, zip_data)
             await self.sync_function_app_triggers(function_app)
-        except Exception:
-            self.log.exception(f"Failed to deploy {component}")
+        except Exception as e:
+            self.log.exception(f"Failed to deploy {component}: {e}")
             return
         self.manifest_cache[component] = self.public_manifest[component]
         self.log.info(f"Finished deploying {component}")
 
-    @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
     async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:
+        # Don't retry the zip deploy to avoid starting multiple deployments
         function_app_url = "https://{}.scm.azurewebsites.{}/api/zipdeploy".format(
             function_app_name, "us" if is_azure_gov(self.region) else "net"
         )

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -4,6 +4,7 @@
 
 # stdlib
 from asyncio import gather, run
+from dataclasses import asdict, replace
 from json import dumps
 from os import environ
 from types import TracebackType
@@ -30,9 +31,12 @@ from cache.manifest_cache import (
     MANIFEST_FILE_NAME,
     PUBLIC_STORAGE_ACCOUNT_URL,
     TASKS_CONTAINER,
+    ComponentState,
     ControlPlaneComponent,
     ManifestCache,
-    deserialize_manifest_cache,
+    PrivateManifestCache,
+    deserialize_private_manifest_cache,
+    deserialize_public_manifest_cache,
 )
 from tasks.common import (
     DIAGNOSTIC_SETTINGS_TASK_PREFIX,
@@ -47,6 +51,7 @@ from tasks.task import Task, task_main
 DEPLOYER_TASK_NAME = "deployer_task"
 
 KUDU_STATUSES_IN_PROGRESS = {0, 1, 2}
+KUDU_STATUS_FAILED = 3
 KUDU_STATUS_SUCCESS = 4
 
 MAX_ATTEMPTS = 5
@@ -59,6 +64,11 @@ class DeployError(Exception):
 
 def get_azure_mgmt_url(region: str) -> str:
     return "https://management." + ("usgovcloudapi.net" if is_azure_gov(region) else "azure.com")
+
+
+def scm_url(region: str, function_app_name: str) -> str:
+    domain = "us" if is_azure_gov(region) else "net"
+    return f"https://{function_app_name}.scm.azurewebsites.{domain}"
 
 
 class DeployerTask(Task):
@@ -104,27 +114,38 @@ class DeployerTask(Task):
         await super().__aexit__(exc_type, exc_val, exc_tb)
 
     async def run(self) -> None:
+        # TODO can the deployer task update the retry values of itself?
+
         public_manifest, private_manifest, current_function_app_ids = await gather(
             self.get_public_manifests(), self.get_private_manifests(), self.get_current_function_apps()
         )
         if not private_manifest:
             self.log.info("Failed to read private manifest. Deploying all components.")
         self.public_manifest = public_manifest
-        self.private_manifest = private_manifest
-        self.manifest_cache = (
-            private_manifest
-            or {
-                "resources": "",
-                "scaling": "",
-                "diagnostic_settings": "",
+        self.private_manifest: PrivateManifestCache | None = private_manifest
+        self.manifest_cache: PrivateManifestCache = (
+            {k: replace(v) for k, v in private_manifest.items()}
+            if private_manifest
+            else {
+                "resources": ComponentState(version="", deployment_url=""),
+                "scaling": ComponentState(version="", deployment_url=""),
+                "diagnostic_settings": ComponentState(version="", deployment_url=""),
             }
-        ).copy()
+        )
+
+        # TODO everywhere raise exception instead of just logging
+        resource_task = next((app for app in current_function_app_ids if app.startswith(RESOURCES_TASK_PREFIX)), None)
+        if not resource_task:
+            self.log.error("Resources task function app not found, will not deploy")
+            return
 
         await gather(
             *[
-                self.deploy_component(component, current_function_app_ids)
+                self.deploy_component(component, current_function_app_ids, resource_task)
                 for component in public_manifest
-                if not private_manifest or public_manifest[component] != private_manifest[component]
+                if not private_manifest
+                or public_manifest[component] != private_manifest[component].version
+                or private_manifest[component].deployment_url
             ]
         )
 
@@ -136,17 +157,17 @@ class DeployerTask(Task):
             raise InvalidCacheError("Public Manifest not found") from e
         blob_data = await stream.readall()
         cache_str = blob_data.decode()
-        if not (cache := deserialize_manifest_cache(cache_str)):
+        if not (cache := deserialize_public_manifest_cache(cache_str)):
             raise InvalidCacheError(f"Invalid Public Manifest: {cache_str}")
         return cache
 
-    async def get_private_manifests(self) -> ManifestCache | None:
+    async def get_private_manifests(self) -> PrivateManifestCache | None:
         try:
             blob_data = await retry(stop=stop_after_attempt(MAX_ATTEMPTS))(read_cache)(MANIFEST_FILE_NAME)
         except RetryError as e:
             self.log.error("Error reading private manifest cache", exc_info=e.last_attempt.exception())
             return None
-        return deserialize_manifest_cache(blob_data)
+        return deserialize_private_manifest_cache(blob_data)
 
     async def get_current_function_apps(self) -> set[str]:
         current_apps = await collect(self.web_client.web_apps.list_by_resource_group(self.resource_group))
@@ -185,80 +206,92 @@ class DeployerTask(Task):
         )
         return True
 
-    async def deploy_component(self, component: ControlPlaneComponent, current_function_app_ids: set[str]) -> None:
+    async def deploy_component(self, component: ControlPlaneComponent, current_function_app_ids: set[str], resources_task_name: str) -> None:
         task_prefix = f"{component.replace('_', '-')}-task-"
         function_app = next((app for app in current_function_app_ids if app.startswith(task_prefix)), None)
         if not function_app:
             self.log.error(f"Function app for {component} not found in {current_function_app_ids}, skipping deployment")
             return
 
-        # TODO error if resources_task not found
-        resources_task = next((app for app in current_function_app_ids if app.startswith(RESOURCES_TASK_PREFIX)), None)
         try:
-            content_share_fixed = await self.fix_content_share(function_app, resources_task or "")
+            content_share_fixed = await self.fix_content_share(function_app, resources_task_name)
         except Exception:
             self.log.exception("Failed to check/fix content share for %s", function_app)
             return
-
         if content_share_fixed:
             self.log.info("Content share fixed for %s, skipping deployment this run", function_app)
             return
 
-        domain = "us" if is_azure_gov(self.region) else "net"
-        status_url = f"https://{function_app}.scm.azurewebsites.{domain}/api/deployments/latest"
-        try:
-            is_complete, is_successful = await self.check_deployment_status(status_url)
-        except DeployError:
-            self.log.exception("Failed to check deployment status for %s, will attempt deployment", component)
-            is_complete, is_successful = True, False
+        if self.manifest_cache[component].deployment_url:
+            self.log.info("Found in-flight deployment for %s, polling deployment status", component)
+            return await self.handle_ongoing_deployment(component, function_app)
+        
+        self.log.info("No in-flight deployment for %s, starting new deployment", component)
+        return await self.start_async_deployment(component, function_app)
 
-        if not is_complete:
-            self.log.info("Deployment in progress for %s, skipping this run", function_app)
+    async def handle_ongoing_deployment(self, component: ControlPlaneComponent, function_app: str) -> None:
+        component_state = self.manifest_cache[component]
+        try:
+            status = await self.get_deployment_status(component_state.deployment_url)
+        except (DeployError, RetryError):
+            # Not sure what we should do
+            self.log.exception("Failed to check deployment status for %s", component)
             return
 
-        if is_successful:
-            try:
-                await self.sync_function_app_triggers(function_app)
-            except Exception as e:
-                self.log.exception("Failed to sync triggers for %s: %s", component, e)
-                return
-            self.manifest_cache[component] = self.public_manifest[component]
-            self.log.info("Finished deploying %s", component)
-            return
+        if status in KUDU_STATUSES_IN_PROGRESS:
+            self.log.info("Deployment still in progress for %s (status: %i)", function_app, status)
+            return  # Preserve version and deployment_url, next run will check deployment again
 
-        # No deployment in progress and last one failed (or none exists) — start a new one
+        if status == KUDU_STATUS_FAILED:
+            self.log.error("Deployment failed for %s, will retry next run", component)
+            component_state.deployment_url = ""
+            return  # Next run sees version mismatch, no deployment_url -> re-deploys
+
         try:
-            zip_data = await self.download_function_app_data(component)
-            await self.upload_function_app_data(function_app, zip_data)
+            await self.sync_function_app_triggers(function_app)
         except Exception as e:
-            self.log.exception("Failed to start deployment for %s: %s", component, e)
-            return
-        self.log.info("Async deploy started for %s, will poll on next run", function_app)
+            self.log.exception("Failed to sync triggers for %s: %s", component, e)
+            return  # Preserve version and deployment_url, next run will check deployment and sync triggers again
 
-    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:
-        # Don't retry the zip deploy to avoid starting multiple deployments
-        function_app_url = "https://{}.scm.azurewebsites.{}/api/zipdeploy?isAsync=true".format(
-            function_app_name, "us" if is_azure_gov(self.region) else "net"
-        )
-        resp = await self.rest_client.post(function_app_url, data=function_app_data)
-        if resp.status != 202:
-            content = (await resp.content.read()).decode()
-            raise DeployError(f"Failed to start async zip deploy: expected 202, got {resp.status} ({resp.reason})\n{content}")
+        component_state.version = self.public_manifest[component]
+        component_state.deployment_url = ""
+        self.log.info("Finished deploying %s", component)
 
-    async def check_deployment_status(self, status_url: str) -> tuple[bool, bool]:
-        """Returns (is_complete, is_successful). Raises DeployError on HTTP error (not 404)."""
+    @retry(stop=stop_after_attempt(3))
+    async def get_deployment_status(self, status_url: str) -> int:
+        """Returns Kudu deployment status code. Raises DeployError on HTTP error or missing status."""
         resp = await self.rest_client.get(status_url)
-        # TODO do we need this?
-        if resp.status == 404:
-            return True, False  # No deployment exists yet — treat as not successful
         if not resp.ok:
             content = (await resp.content.read()).decode()
             raise DeployError(f"Failed to poll deployment status: {resp.status} ({resp.reason})\n{content}")
         body = await resp.json()
-        status: int = body.get("status", 0)
-        if status in KUDU_STATUSES_IN_PROGRESS:
-            return False, False
-        return True, status == KUDU_STATUS_SUCCESS
+        status: int | None = body.get("status")
+        if status is None:
+            raise DeployError(f"Invalid response from deployment status endpoint: {body}")
+        return status
+
+    async def start_async_deployment(self, component: ControlPlaneComponent, function_app: str) -> None:
+        try:
+            zip_data = await self.download_function_app_data(component)
+            poll_url = await self.upload_function_app_data(function_app, zip_data)
+        except Exception as e:
+            self.log.exception("Failed to start deployment for %s: %s", component, e)
+            return
+        # Update deployment URL, but keep version -> next run will poll deployment status instead of starting new deployment
+        self.manifest_cache[component].deployment_url = poll_url
+        self.log.info("Async deploy started for %s, will poll on next run", function_app)
+
+    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> str:
+        # Don't retry the zip deploy to avoid starting multiple deployments
+        function_app_url = scm_url(self.region, function_app_name) + "/api/zipdeploy?isAsync=true"
+        resp = await self.rest_client.post(function_app_url, data=function_app_data)
+        if resp.status != 202:
+            content = (await resp.content.read()).decode()
+            raise DeployError(f"Failed to start async zip deploy: expected 202, got {resp.status} ({resp.reason})\n{content}")
+        poll_url = resp.headers.get("Location")
+        if not poll_url:
+            raise DeployError("Async zip deploy returned 202 but no Location header")
+        return poll_url
 
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
     async def sync_function_app_triggers(self, function_app_name: str) -> None:
@@ -278,7 +311,11 @@ class DeployerTask(Task):
 
     async def write_caches(self) -> None:
         if self.manifest_cache != self.private_manifest:
-            await write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache))
+            serialized = {
+                k: {kk: vv for kk, vv in asdict(v).items() if kk != "deployment_url" or vv}
+                for k, v in self.manifest_cache.items()
+            }
+            await write_cache(MANIFEST_FILE_NAME, dumps(serialized))
 
 
 if __name__ == "__main__":

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -4,7 +4,6 @@
 
 # stdlib
 from asyncio import gather, run
-from dataclasses import asdict
 from json import dumps
 from os import environ
 from types import TracebackType
@@ -29,15 +28,11 @@ from cache.env import (
 from cache.manifest_cache import (
     KEY_TO_ZIP,
     MANIFEST_FILE_NAME,
-    PENDING_DEPLOYMENTS_CACHE_NAME,
     PUBLIC_STORAGE_ACCOUNT_URL,
     TASKS_CONTAINER,
     ControlPlaneComponent,
     ManifestCache,
-    PendingDeployment,
-    PendingDeploymentsCache,
     deserialize_manifest_cache,
-    deserialize_pending_deployments,
 )
 from tasks.common import (
     DIAGNOSTIC_SETTINGS_TASK_PREFIX,
@@ -52,9 +47,7 @@ from tasks.task import Task, task_main
 DEPLOYER_TASK_NAME = "deployer_task"
 
 KUDU_STATUSES_IN_PROGRESS = {0, 1, 2}
-KUDU_STATUS_FAILED = 3
 KUDU_STATUS_SUCCESS = 4
-
 
 MAX_ATTEMPTS = 5
 MAX_WAIT_TIME = 30
@@ -71,10 +64,8 @@ def get_azure_mgmt_url(region: str) -> str:
 class DeployerTask(Task):
     NAME = DEPLOYER_TASK_NAME
 
-    def __init__(self, pending_deployments_state: str = "", is_initial_run: bool = False) -> None:
+    def __init__(self, is_initial_run: bool = False) -> None:
         super().__init__(is_initial_run=is_initial_run)
-        self.pending_deployments: PendingDeploymentsCache = deserialize_pending_deployments(pending_deployments_state)
-        self._initial_pending_deployments: PendingDeploymentsCache = dict(self.pending_deployments)
         self.subscription_id = get_config_option(SUBSCRIPTION_ID_SETTING)
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)
         self.region = get_config_option(CONTROL_PLANE_REGION_SETTING)
@@ -173,7 +164,7 @@ class DeployerTask(Task):
             self.resource_group, function_app_name
         )
         properties = settings.properties or {}
-        
+
         current_value = properties.get("WEBSITE_CONTENTSHARE")
         if current_value != resources_task_name:
             # Variable has already been updated or was created via the python deployment script
@@ -201,10 +192,7 @@ class DeployerTask(Task):
             self.log.error(f"Function app for {component} not found in {current_function_app_ids}, skipping deployment")
             return
 
-        if pending := self.pending_deployments.get(component):
-            await self._check_pending_deployment(component, pending)
-            return
-
+        # TODO error if resources_task not found
         resources_task = next((app for app in current_function_app_ids if app.startswith(RESOURCES_TASK_PREFIX)), None)
         try:
             content_share_fixed = await self.fix_content_share(function_app, resources_task or "")
@@ -216,50 +204,38 @@ class DeployerTask(Task):
             self.log.info("Content share fixed for %s, skipping deployment this run", function_app)
             return
 
-        await self._start_deployment(component, function_app)
+        domain = "us" if is_azure_gov(self.region) else "net"
+        status_url = f"https://{function_app}.scm.azurewebsites.{domain}/api/deployments/latest"
+        try:
+            is_complete, is_successful = await self.check_deployment_status(status_url)
+        except DeployError:
+            self.log.exception("Failed to check deployment status for %s, will attempt deployment", component)
+            is_complete, is_successful = True, False
 
-    async def _start_deployment(self, component: ControlPlaneComponent, function_app: str) -> None:
+        if not is_complete:
+            self.log.info("Deployment in progress for %s, skipping this run", function_app)
+            return
+
+        if is_successful:
+            try:
+                await self.sync_function_app_triggers(function_app)
+            except Exception as e:
+                self.log.exception("Failed to sync triggers for %s: %s", component, e)
+                return
+            self.manifest_cache[component] = self.public_manifest[component]
+            self.log.info("Finished deploying %s", component)
+            return
+
+        # No deployment in progress and last one failed (or none exists) — start a new one
         try:
             zip_data = await self.download_function_app_data(component)
-            poll_url = await self.upload_function_app_data(function_app, zip_data)
+            await self.upload_function_app_data(function_app, zip_data)
         except Exception as e:
             self.log.exception("Failed to start deployment for %s: %s", component, e)
             return
-        self.pending_deployments[component] = PendingDeployment(
-            component=component,
-            function_app=function_app,
-            poll_url=poll_url,
-            target_manifest_hash=self.public_manifest[component],
-        )
         self.log.info("Async deploy started for %s, will poll on next run", function_app)
 
-    async def _check_pending_deployment(self, component: ControlPlaneComponent, pending: PendingDeployment) -> None:
-        try:
-            is_complete, is_successful = await self.check_deployment_status(pending.poll_url)
-        except Exception:
-            self.log.exception("Failed to check deployment status for %s", component)
-            return
-
-        if not is_complete:
-            self.log.info("Deployment still in progress for %s", component)
-            return
-
-        del self.pending_deployments[component]
-
-        if not is_successful:
-            self.log.error("Deployment failed for %s, will retry next run", component)
-            return
-
-        try:
-            await self.sync_function_app_triggers(pending.function_app)
-        except Exception as e:
-            self.log.exception("Failed to sync triggers for %s: %s", component, e)
-            return
-
-        self.manifest_cache[component] = pending.target_manifest_hash
-        self.log.info("Finished deploying %s", component)
-
-    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> str:
+    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:
         # Don't retry the zip deploy to avoid starting multiple deployments
         function_app_url = "https://{}.scm.azurewebsites.{}/api/zipdeploy?isAsync=true".format(
             function_app_name, "us" if is_azure_gov(self.region) else "net"
@@ -268,20 +244,18 @@ class DeployerTask(Task):
         if resp.status != 202:
             content = (await resp.content.read()).decode()
             raise DeployError(f"Failed to start async zip deploy: expected 202, got {resp.status} ({resp.reason})\n{content}")
-        poll_url = resp.headers.get("Location")
-        if not poll_url:
-            raise DeployError("Async zip deploy returned 202 but no Location header")
-        return poll_url
 
-    async def check_deployment_status(self, poll_url: str) -> tuple[bool, bool]:
-        """Returns (is_complete, is_successful). Raises DeployError on HTTP error."""
-        resp = await self.rest_client.get(poll_url)
+    async def check_deployment_status(self, status_url: str) -> tuple[bool, bool]:
+        """Returns (is_complete, is_successful). Raises DeployError on HTTP error (not 404)."""
+        resp = await self.rest_client.get(status_url)
+        # TODO do we need this?
+        if resp.status == 404:
+            return True, False  # No deployment exists yet — treat as not successful
         if not resp.ok:
             content = (await resp.content.read()).decode()
             raise DeployError(f"Failed to poll deployment status: {resp.status} ({resp.reason})\n{content}")
         body = await resp.json()
         status: int = body.get("status", 0)
-        KUDU_STATUS_SUCCESS = 4
         if status in KUDU_STATUSES_IN_PROGRESS:
             return False, False
         return True, status == KUDU_STATUS_SUCCESS
@@ -303,16 +277,9 @@ class DeployerTask(Task):
         return app_data
 
     async def write_caches(self) -> None:
-        writes = []
         if self.manifest_cache != self.private_manifest:
-            writes.append(write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache)))
-        pending_dict = {c: asdict(p) for c, p in self.pending_deployments.items()}
-        initial_dict = {c: asdict(p) for c, p in self._initial_pending_deployments.items()}
-        if pending_dict != initial_dict:
-            writes.append(write_cache(PENDING_DEPLOYMENTS_CACHE_NAME, dumps(pending_dict)))
-        if writes:
-            await gather(*writes)
+            await write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache))
 
 
 if __name__ == "__main__":
-    run(task_main(DeployerTask, [PENDING_DEPLOYMENTS_CACHE_NAME]))
+    run(task_main(DeployerTask, []))

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -164,6 +164,7 @@ class DeployerTask(Task):
         correct_value = f"contentshare-{function_app_name}"
         properties = settings.properties or {}
         if properties.get("WEBSITE_CONTENTSHARE") == correct_value:
+            self.log.info("Content share already correct for %s", function_app_name)
             return False
         self.log.info(
             "Fixing WEBSITE_CONTENTSHARE for %s (was: %s)",
@@ -186,26 +187,22 @@ class DeployerTask(Task):
             return
 
         try:
-            content_share_fixed = await self.fix_content_share(function_app)
+            await self.fix_content_share(function_app)
         except Exception:
             self.log.exception("Failed to check/fix content share for %s", function_app)
             return
 
-        if content_share_fixed:
-            self.log.info("Content share fixed for %s, skipping deployment this run", function_app)
-            return
-
-        try:
-            self.log.info(f"Downloading function app data for {component}")
-            zip_data = await self.download_function_app_data(component)
-            self.log.info(f"Deploying {function_app}")
-            await self.upload_function_app_data(function_app, zip_data)
-            await self.sync_function_app_triggers(function_app)
-        except Exception:
-            self.log.exception(f"Failed to deploy {component}")
-            return
-        self.manifest_cache[component] = self.public_manifest[component]
-        self.log.info(f"Finished deploying {component}")
+        # try:
+        #     self.log.info(f"Downloading function app data for {component}")
+        #     zip_data = await self.download_function_app_data(component)
+        #     self.log.info(f"Deploying {function_app}")
+        #     await self.upload_function_app_data(function_app, zip_data)
+        #     await self.sync_function_app_triggers(function_app)
+        # except Exception:
+        #     self.log.exception(f"Failed to deploy {component}")
+        #     return
+        # self.manifest_cache[component] = self.public_manifest[component]
+        # self.log.info(f"Finished deploying {component}")
 
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
     async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:

--- a/control_plane/tasks/tests/common.py
+++ b/control_plane/tasks/tests/common.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, TypeVar
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 # project
 from cache.common import InvalidCacheError
@@ -50,12 +50,13 @@ class TaskTestCase(AsyncTestCase):
             self.write_cache: AsyncMock = self.patch("write_cache")
 
     def cache_value(self, cache_name: str, deserialize_cache: Callable[[str], T | None]) -> T:
-        self.write_cache.assert_called_with(cache_name, ANY)
-        raw_cache = self.write_cache.call_args_list[-1][0][1]
+        matching_calls = [c for c in self.write_cache.call_args_list if c.args[0] == cache_name]
+        self.assertTrue(matching_calls, f"write_cache not called with {cache_name!r}")
+        raw_cache = matching_calls[-1].args[1]
         cache = deserialize_cache(raw_cache)
         if cache is None:  # pragma: no cover
             # should never happen when tests pass, but it provides a useful error message if they don't
-            raise InvalidCacheError("Diagnostic Settings Cache is in an invalid format after the task")
+            raise InvalidCacheError("Cache is in an invalid format after the task")
         return cache
 
 

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from json import dumps
-from unittest.mock import DEFAULT, MagicMock, call
+from unittest.mock import AsyncMock, DEFAULT, MagicMock, call
 
 # 3p
 from azure.core.exceptions import HttpResponseError
@@ -56,6 +56,10 @@ class TestDeployerTask(TaskTestCase):
         self.web_client = AsyncMockClient()
         self.web_client.web_apps.list_by_resource_group = MagicMock(return_value=async_generator())
         self.web_client.app_service_plans.list_by_resource_group = MagicMock(return_value=async_generator())
+        self.web_client.web_apps.list_application_settings = AsyncMock(
+            side_effect=lambda rg, app_name: mock(properties={"WEBSITE_CONTENTSHARE": f"contentshare-{app_name}"})
+        )
+        self.web_client.web_apps.update_application_settings = AsyncMock()
         self.patch("WebSiteManagementClient").return_value = self.web_client
 
     def set_caches(self, public_cache: ManifestCache, private_cache: ManifestCache):
@@ -305,6 +309,77 @@ class TestDeployerTask(TaskTestCase):
         self.assertEqual(
             self.rest_client.post.mock_calls[0][1][0],
             "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/zipdeploy",
+        )
+
+    async def test_fix_content_share_wrong(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(["resources-task-0863329b4b49"])
+        wrong_settings = mock(properties={"WEBSITE_CONTENTSHARE": "wrong-name"})
+        self.web_client.web_apps.list_application_settings = AsyncMock(return_value=wrong_settings)
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        task = DeployerTask(is_initial_run=False)
+        result = await task.fix_content_share("resources-task-0863329b4b49")
+
+        self.assertTrue(result)
+        self.assertEqual(wrong_settings.properties["WEBSITE_CONTENTSHARE"], "contentshare-resources-task-0863329b4b49")
+        self.web_client.web_apps.update_application_settings.assert_awaited_once()
+
+    async def test_fix_content_share_correct(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(["resources-task-0863329b4b49"])
+        correct_settings = mock(properties={"WEBSITE_CONTENTSHARE": "contentshare-resources-task-0863329b4b49"})
+        self.web_client.web_apps.list_application_settings = AsyncMock(return_value=correct_settings)
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        task = DeployerTask(is_initial_run=False)
+        result = await task.fix_content_share("resources-task-0863329b4b49")
+
+        self.assertFalse(result)
+        self.web_client.web_apps.update_application_settings.assert_not_awaited()
+
+    async def test_deploy_skipped_after_content_share_fix(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.web_client.web_apps.list_application_settings = AsyncMock(
+            return_value=mock(properties={"WEBSITE_CONTENTSHARE": "wrong-name"})
+        )
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        await self.run_deployer_task()
+
+        self.web_client.web_apps.update_application_settings.assert_awaited()
+        self.rest_client.post.assert_not_awaited()
+        self.write_cache.assert_not_awaited()
+
+    async def test_deploy_proceeds_when_content_share_correct(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(["resources-task-0863329b4b49"])
+
+        def correct_settings(resource_group, function_app_name):
+            return mock(properties={"WEBSITE_CONTENTSHARE": f"contentshare-{function_app_name}"})
+
+        self.web_client.web_apps.list_application_settings = AsyncMock(side_effect=correct_settings)
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        await self.run_deployer_task()
+
+        self.web_client.web_apps.update_application_settings.assert_not_awaited()
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
         )
 
     async def test_deployer_tags(self):

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -311,35 +311,56 @@ class TestDeployerTask(TaskTestCase):
             "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/zipdeploy",
         )
 
-    async def test_fix_content_share_wrong(self):
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_function_apps(["resources-task-0863329b4b49"])
-        wrong_settings = mock(properties={"WEBSITE_CONTENTSHARE": "wrong-name"})
+    async def test_fix_content_share__fixes_wrong_value(self):
+        wrong_settings = mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49"})
         self.web_client.web_apps.list_application_settings = AsyncMock(return_value=wrong_settings)
         self.web_client.web_apps.update_application_settings = AsyncMock()
-
         task = DeployerTask(is_initial_run=False)
-        result = await task.fix_content_share("resources-task-0863329b4b49")
 
+        # check that the fix is applied to the resources-task
+        result = await task.fix_content_share("resources-task-0863329b4b49", "resources-task-0863329b4b49")
         self.assertTrue(result)
         self.assertEqual(wrong_settings.properties["WEBSITE_CONTENTSHARE"], "contentshare-resources-task-0863329b4b49")
         self.web_client.web_apps.update_application_settings.assert_awaited_once()
 
-    async def test_fix_content_share_correct(self):
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_function_apps(["resources-task-0863329b4b49"])
+        # check that the fix is applied to the scaling-task
+        wrong_scaling_settings = mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49"})
+        self.web_client.web_apps.list_application_settings = AsyncMock(return_value=wrong_scaling_settings)
+        self.web_client.web_apps.update_application_settings.reset_mock()
+        result = await task.fix_content_share("scaling-task-0863329b4b49", "resources-task-0863329b4b49")
+        self.assertTrue(result)
+        self.assertEqual(wrong_scaling_settings.properties["WEBSITE_CONTENTSHARE"], "contentshare-scaling-task-0863329b4b49")
+        self.web_client.web_apps.update_application_settings.assert_awaited_once()
+
+    async def test_fix_content_share__fixes_unrecognized_value(self):
+        unrecognized_settings = mock(properties={"WEBSITE_CONTENTSHARE": "some-other-value"})
+        self.web_client.web_apps.list_application_settings = AsyncMock(return_value=unrecognized_settings)
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        task = DeployerTask(is_initial_run=False)
+        result = await task.fix_content_share("resources-task-0863329b4b49", "resources-task-0863329b4b49")
+
+        self.assertFalse(result)
+        self.web_client.web_apps.update_application_settings.assert_not_awaited()
+
+    async def test_fix_content_share__skips_correct_value(self):
         correct_settings = mock(properties={"WEBSITE_CONTENTSHARE": "contentshare-resources-task-0863329b4b49"})
         self.web_client.web_apps.list_application_settings = AsyncMock(return_value=correct_settings)
         self.web_client.web_apps.update_application_settings = AsyncMock()
 
         task = DeployerTask(is_initial_run=False)
-        result = await task.fix_content_share("resources-task-0863329b4b49")
+        result = await task.fix_content_share("resources-task-0863329b4b49", "resources-task-0863329b4b49")
+
+        self.assertFalse(result)
+        self.web_client.web_apps.update_application_settings.assert_not_awaited()
+    
+    async def test_fix_content_share__skips_python_script_value(self):
+        correct_settings = mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49123412341234"})
+        self.web_client.web_apps.list_application_settings = AsyncMock(return_value=correct_settings)
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        task = DeployerTask(is_initial_run=False)
+        result = await task.fix_content_share("resources-task-0863329b4b49", "resources-task-0863329b4b49")
 
         self.assertFalse(result)
         self.web_client.web_apps.update_application_settings.assert_not_awaited()
@@ -351,7 +372,7 @@ class TestDeployerTask(TaskTestCase):
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.web_client.web_apps.list_application_settings = AsyncMock(
-            return_value=mock(properties={"WEBSITE_CONTENTSHARE": "wrong-name"})
+            return_value=mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49"})
         )
         self.web_client.web_apps.update_application_settings = AsyncMock()
 
@@ -361,7 +382,7 @@ class TestDeployerTask(TaskTestCase):
         self.rest_client.post.assert_not_awaited()
         self.write_cache.assert_not_awaited()
 
-    async def test_deploy_proceeds_when_content_share_correct(self):
+    async def test_deploy_proceeds_when_content_share_is_correct_value(self):
         self.set_caches(
             public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
@@ -370,6 +391,27 @@ class TestDeployerTask(TaskTestCase):
 
         def correct_settings(resource_group, function_app_name):
             return mock(properties={"WEBSITE_CONTENTSHARE": f"contentshare-{function_app_name}"})
+
+        self.web_client.web_apps.list_application_settings = AsyncMock(side_effect=correct_settings)
+        self.web_client.web_apps.update_application_settings = AsyncMock()
+
+        await self.run_deployer_task()
+
+        self.web_client.web_apps.update_application_settings.assert_not_awaited()
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+        )
+
+    async def test_deploy_proceeds_when_content_share_is_python_script_value(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(["resources-task-0863329b4b49"])
+
+        def correct_settings(resource_group, function_app_name):
+            return mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49123412341234"})
 
         self.web_client.web_apps.list_application_settings = AsyncMock(side_effect=correct_settings)
         self.web_client.web_apps.update_application_settings = AsyncMock()

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -17,14 +17,7 @@ from cache.env import (
     RESOURCE_GROUP_SETTING,
     SUBSCRIPTION_ID_SETTING,
 )
-from cache.manifest_cache import (
-    MANIFEST_CACHE_NAME,
-    PENDING_DEPLOYMENTS_CACHE_NAME,
-    ManifestCache,
-    PendingDeployment,
-    deserialize_manifest_cache,
-    deserialize_pending_deployments,
-)
+from cache.manifest_cache import MANIFEST_CACHE_NAME, ManifestCache, deserialize_manifest_cache
 from tasks.deployer_task import DEPLOYER_TASK_NAME, DeployError, DeployerTask
 from tasks.tests.common import AsyncMockClient, TaskTestCase, async_generator, mock
 from tasks.version import VERSION
@@ -35,15 +28,7 @@ ALL_FUNCTIONS = [
     "diagnostic-settings-task-0863329b4b49",
 ]
 
-RESOURCES_POLL_URL = "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
-SCALING_POLL_URL = "https://scaling-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
-DS_POLL_URL = "https://diagnostic-settings-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
-
-
-def make_pending_state(*pending: PendingDeployment) -> str:
-    return dumps({p.component: {"component": p.component, "function_app": p.function_app,
-                                "poll_url": p.poll_url, "target_manifest_hash": p.target_manifest_hash}
-                  for p in pending})
+RESOURCES_STATUS_URL = "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
 
 
 class TestDeployerTask(TaskTestCase):
@@ -52,10 +37,6 @@ class TestDeployerTask(TaskTestCase):
     @property
     def cache(self) -> ManifestCache:
         return self.cache_value(MANIFEST_CACHE_NAME, deserialize_manifest_cache)
-
-    @property
-    def pending_cache(self):
-        return self.cache_value(PENDING_DEPLOYMENTS_CACHE_NAME, deserialize_pending_deployments)
 
     def setUp(self) -> None:
         super().setUp()
@@ -72,12 +53,11 @@ class TestDeployerTask(TaskTestCase):
         self.patch("ContainerClient").return_value = self.public_client
         self.read_private_cache = self.patch("read_cache")
         self.rest_client = AsyncMockClient()
-        self.rest_client.post.return_value = MagicMock(
-            status=202,
-            headers={"Location": RESOURCES_POLL_URL},
-        )
+        # Default: GET returns success (deployment complete), POST returns 202
         self.rest_client.get.return_value.ok = True
+        self.rest_client.get.return_value.status = 200
         self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
+        self.rest_client.post.return_value = MagicMock(ok=True)
         self.patch("ClientSession").return_value = self.rest_client
         self.web_client = AsyncMockClient()
         self.web_client.web_apps.list_by_resource_group = MagicMock(return_value=async_generator())
@@ -97,13 +77,20 @@ class TestDeployerTask(TaskTestCase):
             *(mock(name=app) for app in function_apps)
         )
 
-    async def run_deployer_task(self, pending_deployments_state: str = "") -> DeployerTask:
-        async with DeployerTask(pending_deployments_state, is_initial_run=False) as task:
+    def set_kudu_in_progress(self):
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": False, "status": 1})
+
+    def set_kudu_no_deployment(self):
+        self.rest_client.get.return_value.ok = False
+        self.rest_client.get.return_value.status = 404
+
+    async def run_deployer_task(self) -> DeployerTask:
+        async with DeployerTask(is_initial_run=False) as task:
             await task.run()
         return task
 
     # -------------------------------------------------------------------------
-    # Existing integration tests
+    # Integration tests
     # -------------------------------------------------------------------------
 
     async def test_deploy_task_no_diff(self):
@@ -125,8 +112,8 @@ class TestDeployerTask(TaskTestCase):
 
         self.write_cache.assert_not_awaited()
 
-    async def test_deploy_task_starts_async_deploy(self):
-        """First run with a diff: starts async deploy, writes pending, does NOT update manifest."""
+    async def test_deploy_task_diff_func_app(self):
+        """Kudu shows success: sync triggers, update manifest."""
         public_cache: ManifestCache = {
             "resources": "2",
             "scaling": "1",
@@ -144,42 +131,10 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        # async URL used
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy?isAsync=true",
-        )
-        # pending written, manifest NOT written
-        pending = self.pending_cache
-        self.assertIn("resources", pending)
-        self.assertEqual(pending["resources"].target_manifest_hash, "2")
-        manifest_written_calls = [c for c in self.write_cache.call_args_list if c.args[0] == MANIFEST_CACHE_NAME]
-        self.assertFalse(manifest_written_calls)
-
-    async def test_deploy_task_diff_func_app(self):
-        """Second run (pending exists): completes deploy, updates manifest."""
-        public_cache: ManifestCache = {
-            "resources": "2",
-            "scaling": "1",
-            "diagnostic_settings": "1",
-        }
-        self.set_caches(
-            public_cache=public_cache,
-            private_cache={
-                "resources": "1",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
-        self.set_current_function_apps(ALL_FUNCTIONS)
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
-
-        await self.run_deployer_task(pending_state)
-
         self.assertEqual(self.cache, public_cache)
-        # sync_function_app_triggers uses POST; no zip deploy POST
+        # GET was used to check deployment status
+        self.rest_client.get.assert_awaited()
+        # No zip deploy POST (deployment already succeeded per Kudu)
         zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
         self.assertFalse(zip_calls)
 
@@ -198,13 +153,51 @@ class TestDeployerTask(TaskTestCase):
             },
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
 
-        await self.run_deployer_task(pending_state)
+        await self.run_deployer_task()
 
         self.assertEqual(self.cache, public_cache)
+
+    async def test_deploy_task_starts_async_deploy_when_no_kudu_deployment(self):
+        """Kudu returns 404 (no prior deployment): start async zip deploy, don't update manifest."""
+        public_cache: ManifestCache = {
+            "resources": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
+        }
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={
+                "resources": "1",
+                "scaling": "1",
+                "diagnostic_settings": "1",
+            },
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.set_kudu_no_deployment()
+        self.rest_client.post.return_value = MagicMock(status=202)
+
+        await self.run_deployer_task()
+
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy?isAsync=true",
+        )
+        self.write_cache.assert_not_awaited()
+
+    async def test_deploy_task_skips_when_deployment_in_progress(self):
+        """Kudu shows in-progress: skip, don't deploy, don't update manifest."""
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.set_kudu_in_progress()
+
+        await self.run_deployer_task()
+
+        self.rest_client.post.assert_not_awaited()
+        self.write_cache.assert_not_awaited()
 
     async def test_partial_success_func_app(self):
         self.set_caches(
@@ -226,16 +219,24 @@ class TestDeployerTask(TaskTestCase):
                 raise HttpResponseError()
             return DEFAULT
 
+        # resources: Kudu success → sync + update manifest
+        # diagnostic_settings: Kudu 404 → attempt deploy → download fails
+        def _get_side_effect(url: str, **kwargs):
+            m = MagicMock()
+            m.ok = True
+            m.status = 200
+            if "diagnostic-settings" in url:
+                m.ok = False
+                m.status = 404
+            m.json = AsyncMock(return_value={"complete": True, "status": 4})
+            m.content.read = AsyncMock(return_value=b"")
+            return m
+
+        self.rest_client.get.side_effect = _get_side_effect
         self.public_client.download_blob.side_effect = _download_blob
 
-        # Pre-populate resources pending; diagnostic_settings will fail to start again this run
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
+        await self.run_deployer_task()
 
-        await self.run_deployer_task(pending_state)
-
-        # resources completed, diagnostic_settings failed → only resources updated
         self.assertEqual(
             self.cache,
             {
@@ -244,7 +245,6 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
-        # diagnostic_settings download was retried 5 times
         self.public_client.download_blob.assert_has_calls(
             [
                 call("manifest.json"),
@@ -279,22 +279,17 @@ class TestDeployerTask(TaskTestCase):
     async def test_deploy_task_no_private_manifests(self):
         public_cache: ManifestCache = {
             "resources": "2",
-            "scaling": "2",
-            "diagnostic_settings": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
         }
         self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
         self.read_private_cache.return_value = ""
         self.set_current_function_apps(ALL_FUNCTIONS)
 
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2"),
-            PendingDeployment("scaling", "scaling-task-0863329b4b49", SCALING_POLL_URL, "2"),
-            PendingDeployment("diagnostic_settings", "diagnostic-settings-task-0863329b4b49", DS_POLL_URL, "2"),
-        )
+        await self.run_deployer_task()
 
-        await self.run_deployer_task(pending_state)
-
-        self.assertEqual(self.cache, public_cache)
+        public_cache_str = dumps(public_cache)
+        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
 
     async def test_deploy_task_no_manifests(self):
         self.public_client.download_blob.return_value.readall.return_value = b""
@@ -311,25 +306,21 @@ class TestDeployerTask(TaskTestCase):
     async def test_deploy_task_private_manifest_retry_error(self):
         public_cache: ManifestCache = {
             "resources": "2",
-            "scaling": "2",
-            "diagnostic_settings": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
         }
         self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
         self.read_private_cache.side_effect = HttpResponseError
         self.set_current_function_apps(ALL_FUNCTIONS)
 
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2"),
-            PendingDeployment("scaling", "scaling-task-0863329b4b49", SCALING_POLL_URL, "2"),
-            PendingDeployment("diagnostic_settings", "diagnostic-settings-task-0863329b4b49", DS_POLL_URL, "2"),
-        )
+        await self.run_deployer_task()
 
-        await self.run_deployer_task(pending_state)
-
+        public_cache_str = dumps(public_cache)
         self.assertEqual(self.read_private_cache.await_count, 5)
-        self.assertEqual(self.cache, public_cache)
+        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
 
     async def test_post_func_app_fails(self):
+        """Kudu 404 → attempt deploy → POST returns 400 (no retry): manifest not updated."""
         self.set_caches(
             public_cache={
                 "resources": "2",
@@ -342,7 +333,9 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
+        self.set_kudu_no_deployment()
         self.rest_client.post.return_value = MagicMock(status=400)
+        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         await self.run_deployer_task()
@@ -367,16 +360,14 @@ class TestDeployerTask(TaskTestCase):
             },
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
-        gov_poll_url = "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/deployments/latest"
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", gov_poll_url, "2")
-        )
 
-        await self.run_deployer_task(pending_state)
+        await self.run_deployer_task()
 
         self.credential.get_token.assert_awaited_once_with("https://management.usgovcloudapi.net/.default")
-
         self.assertEqual(self.cache, public_cache)
+        # GET status was checked on the .us domain
+        get_urls = [str(c) for c in self.rest_client.get.call_args_list]
+        self.assertTrue(any("azurewebsites.us" in u for u in get_urls))
 
     async def test_fix_content_share__fixes_wrong_value(self):
         wrong_settings = mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49"})
@@ -455,6 +446,8 @@ class TestDeployerTask(TaskTestCase):
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(["resources-task-0863329b4b49"])
+        self.set_kudu_no_deployment()
+        self.rest_client.post.return_value = MagicMock(status=202)
 
         def correct_settings(resource_group, function_app_name):
             return mock(properties={"WEBSITE_CONTENTSHARE": f"contentshare-{function_app_name}"})
@@ -476,6 +469,8 @@ class TestDeployerTask(TaskTestCase):
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(["resources-task-0863329b4b49"])
+        self.set_kudu_no_deployment()
+        self.rest_client.post.return_value = MagicMock(status=202)
 
         def correct_settings(resource_group, function_app_name):
             return mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49123412341234"})
@@ -523,36 +518,20 @@ class TestDeployerTask(TaskTestCase):
     # upload_function_app_data tests
     # -------------------------------------------------------------------------
 
-    async def test_upload_function_app_data_returns_poll_url(self):
-        poll_url = "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
-        self.rest_client.post.return_value = MagicMock(
-            status=202,
-            headers={"Location": poll_url},
-        )
+    async def test_upload_function_app_data_succeeds_on_202(self):
+        self.rest_client.post.return_value = MagicMock(status=202)
         task = DeployerTask()
-        result = await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
-        self.assertEqual(result, poll_url)
+        # Should not raise
+        await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
+        self.rest_client.post.assert_awaited_once()
 
     async def test_upload_function_app_data_raises_on_non_202(self):
-        self.rest_client.post.return_value = MagicMock(
-            status=400,
-            reason="Bad Request",
-        )
+        self.rest_client.post.return_value = MagicMock(status=400, reason="Bad Request")
         self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"error body")
         task = DeployerTask()
         with self.assertRaises(DeployError) as ctx:
             await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
         self.assertIn("expected 202, got 400", str(ctx.exception))
-
-    async def test_upload_function_app_data_raises_on_missing_location(self):
-        self.rest_client.post.return_value = MagicMock(
-            status=202,
-            headers={},
-        )
-        task = DeployerTask()
-        with self.assertRaises(DeployError) as ctx:
-            await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
-        self.assertIn("no Location header", str(ctx.exception))
 
     # -------------------------------------------------------------------------
     # check_deployment_status tests
@@ -564,21 +543,30 @@ class TestDeployerTask(TaskTestCase):
             self.rest_client.get.return_value.json = AsyncMock(
                 return_value={"complete": False, "status": in_progress_status}
             )
-            is_complete, is_successful = await task.check_deployment_status(RESOURCES_POLL_URL)
+            is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
             self.assertFalse(is_complete)
             self.assertFalse(is_successful)
 
     async def test_check_deployment_status_success(self):
         self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
         task = DeployerTask()
-        is_complete, is_successful = await task.check_deployment_status(RESOURCES_POLL_URL)
+        is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
         self.assertTrue(is_complete)
         self.assertTrue(is_successful)
 
     async def test_check_deployment_status_failed(self):
         self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 3})
         task = DeployerTask()
-        is_complete, is_successful = await task.check_deployment_status(RESOURCES_POLL_URL)
+        is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
+        self.assertTrue(is_complete)
+        self.assertFalse(is_successful)
+
+    async def test_check_deployment_status_not_found(self):
+        """404 → no deployment exists, treat as (complete=True, successful=False) to trigger a new deploy."""
+        self.rest_client.get.return_value.ok = False
+        self.rest_client.get.return_value.status = 404
+        task = DeployerTask()
+        is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
         self.assertTrue(is_complete)
         self.assertFalse(is_successful)
 
@@ -589,146 +577,90 @@ class TestDeployerTask(TaskTestCase):
         self.rest_client.get.return_value.content.read = AsyncMock(return_value=b"server error")
         task = DeployerTask()
         with self.assertRaises(DeployError):
-            await task.check_deployment_status(RESOURCES_POLL_URL)
+            await task.check_deployment_status(RESOURCES_STATUS_URL)
 
     # -------------------------------------------------------------------------
     # deploy_component state machine tests
     # -------------------------------------------------------------------------
 
-    async def test_deploy_component_no_pending_starts_deploy(self):
-        """No pending deployment: starts async deploy, populates pending_deployments, does NOT sync or update manifest."""
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+    async def test_deploy_component_kudu_in_progress_skips(self):
+        """Deployment already in progress: no new deploy, manifest unchanged."""
         self.set_caches(
-            public_cache=public_cache,
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.set_kudu_in_progress()
+
+        task = await self.run_deployer_task()
+
+        self.rest_client.post.assert_not_awaited()
+        self.assertEqual(task.manifest_cache["resources"], "1")
+        self.write_cache.assert_not_awaited()
+
+    async def test_deploy_component_kudu_success_syncs_and_updates_manifest(self):
+        """Kudu shows success: sync triggers, update manifest, no new zip deploy."""
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         task = await self.run_deployer_task()
 
-        self.rest_client.post.assert_awaited_once()
-        self.rest_client.get.assert_not_awaited()
-        # sync triggers was NOT called (only POST to zipdeploy)
-        post_url = self.rest_client.post.call_args[0][0]
-        self.assertIn("zipdeploy?isAsync=true", post_url)
-        # pending_deployments written
-        pending = self.pending_cache
-        self.assertIn("resources", pending)
-        # manifest NOT updated
-        self.assertEqual(task.manifest_cache["resources"], "1")
-
-    async def test_deploy_component_pending_in_progress(self):
-        """Pending deployment still in progress: no new POST, preserves pending."""
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
-        self.set_caches(
-            public_cache=public_cache,
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_function_apps(ALL_FUNCTIONS)
-        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": False, "status": 1})
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
-
-        task = await self.run_deployer_task(pending_state)
-
-        self.rest_client.post.assert_not_awaited()
-        self.rest_client.get.assert_awaited_once()
-        # pending preserved (still in pending_deployments)
-        self.assertIn("resources", task.pending_deployments)
-        # manifest NOT updated
-        self.assertEqual(task.manifest_cache["resources"], "1")
-        # Nothing written (pending unchanged from initial state)
-        self.write_cache.assert_not_awaited()
-
-    async def test_deploy_component_pending_succeeds(self):
-        """Pending deployment succeeds: syncs triggers, updates manifest, clears pending."""
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
-        self.set_caches(
-            public_cache=public_cache,
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_function_apps(ALL_FUNCTIONS)
-        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
-
-        task = await self.run_deployer_task(pending_state)
-
-        self.rest_client.post.assert_awaited()  # sync triggers calls POST
-        self.rest_client.get.assert_awaited_once()
-        self.assertNotIn("resources", task.pending_deployments)
+        zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
+        self.assertFalse(zip_calls)
         self.assertEqual(task.manifest_cache["resources"], "2")
-        self.assertEqual(self.cache, public_cache)
+        self.assertEqual(self.cache["resources"], "2")
 
-    async def test_deploy_component_pending_fails(self):
-        """Pending deployment fails: clears pending, does NOT update manifest."""
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+    async def test_deploy_component_kudu_failed_starts_new_deploy(self):
+        """Kudu shows failure: start a new deployment."""
         self.set_caches(
-            public_cache=public_cache,
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 3})
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
+        self.rest_client.post.return_value = MagicMock(status=202)
 
-        task = await self.run_deployer_task(pending_state)
+        task = await self.run_deployer_task()
 
-        self.assertNotIn("resources", task.pending_deployments)
+        zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
+        self.assertTrue(zip_calls)
+        # Manifest not updated (deployment just started)
         self.assertEqual(task.manifest_cache["resources"], "1")
-        # manifest NOT written (unchanged), pending IS written (cleared)
-        pending_written_calls = [c for c in self.write_cache.call_args_list
-                                 if c.args[0] == PENDING_DEPLOYMENTS_CACHE_NAME]
-        self.assertTrue(pending_written_calls)
-        manifest_written_calls = [c for c in self.write_cache.call_args_list
-                                   if c.args[0] == MANIFEST_CACHE_NAME]
-        self.assertFalse(manifest_written_calls)
+        self.write_cache.assert_not_awaited()
 
-    async def test_deploy_component_status_check_error_preserves_pending(self):
-        """Status check HTTP error: preserves pending, does not crash."""
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+    async def test_deploy_component_sync_triggers_fails_no_manifest_update(self):
+        """Sync triggers fails after Kudu success: manifest NOT updated."""
         self.set_caches(
-            public_cache=public_cache,
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        # Kudu success, but sync triggers POST fails (all 5 retries)
+        self.rest_client.post.return_value = MagicMock(ok=False, status=500, reason="Error")
+        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
+
+        task = await self.run_deployer_task()
+
+        self.assertEqual(task.manifest_cache["resources"], "1")
+        self.write_cache.assert_not_awaited()
+
+    async def test_deploy_component_status_check_error_attempts_deploy(self):
+        """Kudu check raises DeployError (e.g. 500): fall through to attempting a new deployment."""
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.rest_client.get.return_value.ok = False
         self.rest_client.get.return_value.status = 500
-        self.rest_client.get.return_value.reason = "Server Error"
+        self.rest_client.get.return_value.reason = "Error"
         self.rest_client.get.return_value.content.read = AsyncMock(return_value=b"")
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
+        self.rest_client.post.return_value = MagicMock(status=202)
 
-        task = await self.run_deployer_task(pending_state)
+        await self.run_deployer_task()
 
-        # Pending preserved
-        self.assertIn("resources", task.pending_deployments)
-        # Nothing written
-        self.write_cache.assert_not_awaited()
-
-    async def test_deploy_component_sync_triggers_fails_no_manifest_update(self):
-        """Sync triggers fails after successful deploy: manifest NOT updated, pending cleared."""
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
-        self.set_caches(
-            public_cache=public_cache,
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_function_apps(ALL_FUNCTIONS)
-        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
-        # sync triggers POST fails (all 5 retries)
-        self.rest_client.post.return_value = MagicMock(ok=False, status=500, reason="Error")
-        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
-        pending_state = make_pending_state(
-            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
-        )
-
-        task = await self.run_deployer_task(pending_state)
-
-        # Pending cleared (deployment completed, even though triggers failed)
-        self.assertNotIn("resources", task.pending_deployments)
-        # Manifest NOT updated
-        self.assertEqual(task.manifest_cache["resources"], "1")
+        zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
+        self.assertTrue(zip_calls)

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, DEFAULT, MagicMock, call
 
 # 3p
 from azure.core.exceptions import HttpResponseError
+from tenacity import RetryError
 
 # project
 from cache.common import InvalidCacheError
@@ -17,7 +18,13 @@ from cache.env import (
     RESOURCE_GROUP_SETTING,
     SUBSCRIPTION_ID_SETTING,
 )
-from cache.manifest_cache import MANIFEST_CACHE_NAME, ManifestCache, deserialize_manifest_cache
+from cache.manifest_cache import (
+    MANIFEST_CACHE_NAME,
+    ManifestCache,
+    PrivateManifestCache,
+    deserialize_manifest_cache,
+    deserialize_private_manifest_cache,
+)
 from tasks.deployer_task import DEPLOYER_TASK_NAME, DeployError, DeployerTask
 from tasks.tests.common import AsyncMockClient, TaskTestCase, async_generator, mock
 from tasks.version import VERSION
@@ -35,8 +42,8 @@ class TestDeployerTask(TaskTestCase):
     TASK_NAME = DEPLOYER_TASK_NAME
 
     @property
-    def cache(self) -> ManifestCache:
-        return self.cache_value(MANIFEST_CACHE_NAME, deserialize_manifest_cache)
+    def cache(self) -> PrivateManifestCache:
+        return self.cache_value(MANIFEST_CACHE_NAME, deserialize_private_manifest_cache)
 
     def setUp(self) -> None:
         super().setUp()
@@ -53,11 +60,15 @@ class TestDeployerTask(TaskTestCase):
         self.patch("ContainerClient").return_value = self.public_client
         self.read_private_cache = self.patch("read_cache")
         self.rest_client = AsyncMockClient()
-        # Default: GET returns success (deployment complete), POST returns 202
+        # Default: GET returns success (deployment complete), POST returns 202 + Location
         self.rest_client.get.return_value.ok = True
         self.rest_client.get.return_value.status = 200
         self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
-        self.rest_client.post.return_value = MagicMock(ok=True)
+        self.rest_client.post.return_value = MagicMock(
+            status=202,
+            ok=True,
+            headers={"Location": RESOURCES_STATUS_URL},
+        )
         self.patch("ClientSession").return_value = self.rest_client
         self.web_client = AsyncMockClient()
         self.web_client.web_apps.list_by_resource_group = MagicMock(return_value=async_generator())
@@ -68,9 +79,11 @@ class TestDeployerTask(TaskTestCase):
         self.web_client.web_apps.update_application_settings = AsyncMock()
         self.patch("WebSiteManagementClient").return_value = self.web_client
 
-    def set_caches(self, public_cache: ManifestCache, private_cache: ManifestCache):
+    def set_caches(self, public_cache: ManifestCache, private_cache: dict):
         self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
-        self.read_private_cache.return_value = dumps(private_cache)
+        # private_cache accepts dict[component, str] for convenience and wraps in ComponentState format
+        private_serialized = {k: {"version": v} for k, v in private_cache.items()}
+        self.read_private_cache.return_value = dumps(private_serialized)
 
     def set_current_function_apps(self, function_apps: list[str]):
         self.web_client.web_apps.list_by_resource_group.return_value = async_generator(
@@ -113,7 +126,7 @@ class TestDeployerTask(TaskTestCase):
         self.write_cache.assert_not_awaited()
 
     async def test_deploy_task_diff_func_app(self):
-        """Kudu shows success: sync triggers, update manifest."""
+        """Deployment URL in cache, Kudu shows success: sync triggers, update manifest."""
         public_cache: ManifestCache = {
             "resources": "2",
             "scaling": "1",
@@ -127,11 +140,18 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
+        # Pre-populate deployment_url so the poll path is taken
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         await self.run_deployer_task()
 
-        self.assertEqual(self.cache, public_cache)
+        self.assertEqual(self.cache["resources"].version, "2")
+        self.assertFalse(self.cache["resources"].deployment_url)
         # GET was used to check deployment status
         self.rest_client.get.assert_awaited()
         # No zip deploy POST (deployment already succeeded per Kudu)
@@ -144,22 +164,21 @@ class TestDeployerTask(TaskTestCase):
             "scaling": "1",
             "diagnostic_settings": "1",
         }
-        self.set_caches(
-            public_cache=public_cache,
-            private_cache={
-                "resources": "1",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
+        # Pre-populate deployment_url so the poll path is taken
+        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         await self.run_deployer_task()
 
-        self.assertEqual(self.cache, public_cache)
+        self.assertEqual(self.cache["resources"].version, "2")
 
-    async def test_deploy_task_starts_async_deploy_when_no_kudu_deployment(self):
-        """Kudu returns 404 (no prior deployment): start async zip deploy, don't update manifest."""
+    async def test_deploy_task_starts_async_deploy_when_no_deployment_url(self):
+        """No deployment_url in cache: start async zip deploy, don't update manifest version."""
         public_cache: ManifestCache = {
             "resources": "2",
             "scaling": "1",
@@ -174,8 +193,7 @@ class TestDeployerTask(TaskTestCase):
             },
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
-        self.set_kudu_no_deployment()
-        self.rest_client.post.return_value = MagicMock(status=202)
+        # Default POST returns 202 + Location
 
         await self.run_deployer_task()
 
@@ -183,14 +201,20 @@ class TestDeployerTask(TaskTestCase):
             self.rest_client.post.mock_calls[0][1][0],
             "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy?isAsync=true",
         )
-        self.write_cache.assert_not_awaited()
+        # Deployment URL stored in cache, version not yet updated
+        self.assertEqual(self.cache["resources"].version, "1")
+        self.assertEqual(self.cache["resources"].deployment_url, RESOURCES_STATUS_URL)
 
     async def test_deploy_task_skips_when_deployment_in_progress(self):
-        """Kudu shows in-progress: skip, don't deploy, don't update manifest."""
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
+        """Deployment URL in cache, Kudu shows in-progress: skip, don't deploy, don't update manifest."""
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        ).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.set_kudu_in_progress()
 
@@ -200,18 +224,16 @@ class TestDeployerTask(TaskTestCase):
         self.write_cache.assert_not_awaited()
 
     async def test_partial_success_func_app(self):
-        self.set_caches(
-            public_cache={
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "2",
-            },
-            private_cache={
-                "resources": "1",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "2"}
+        ).encode()
+        # resources has deployment_url → poll path (GET returns success)
+        # diagnostic_settings has no deployment_url → start path → download fails
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         def _download_blob(item: str):
@@ -219,32 +241,12 @@ class TestDeployerTask(TaskTestCase):
                 raise HttpResponseError()
             return DEFAULT
 
-        # resources: Kudu success → sync + update manifest
-        # diagnostic_settings: Kudu 404 → attempt deploy → download fails
-        def _get_side_effect(url: str, **kwargs):
-            m = MagicMock()
-            m.ok = True
-            m.status = 200
-            if "diagnostic-settings" in url:
-                m.ok = False
-                m.status = 404
-            m.json = AsyncMock(return_value={"complete": True, "status": 4})
-            m.content.read = AsyncMock(return_value=b"")
-            return m
-
-        self.rest_client.get.side_effect = _get_side_effect
         self.public_client.download_blob.side_effect = _download_blob
 
         await self.run_deployer_task()
 
-        self.assertEqual(
-            self.cache,
-            {
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
+        self.assertEqual(self.cache["resources"].version, "2")
+        self.assertEqual(self.cache["diagnostic_settings"].version, "1")
         self.public_client.download_blob.assert_has_calls(
             [
                 call("manifest.json"),
@@ -262,9 +264,9 @@ class TestDeployerTask(TaskTestCase):
         self.public_client.download_blob.return_value.readall.return_value = b"invalid"
         self.read_private_cache.return_value = dumps(
             {
-                "resources": "1",
-                "diagnostic_settings": "1",
-                "scaling": "1",
+                "resources": {"version": "1"},
+                "diagnostic_settings": {"version": "1"},
+                "scaling": {"version": "1"},
             }
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
@@ -288,8 +290,8 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        public_cache_str = dumps(public_cache)
-        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
+        # Deployment URLs are stored in cache (versions not yet updated since deploy just started)
+        self.write_cache.assert_awaited_once()
 
     async def test_deploy_task_no_manifests(self):
         self.public_client.download_blob.return_value.readall.return_value = b""
@@ -315,12 +317,12 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        public_cache_str = dumps(public_cache)
         self.assertEqual(self.read_private_cache.await_count, 5)
-        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
+        # Deployment URLs are stored in cache (deploy just started for all components)
+        self.write_cache.assert_awaited_once()
 
     async def test_post_func_app_fails(self):
-        """Kudu 404 → attempt deploy → POST returns 400 (no retry): manifest not updated."""
+        """No deployment_url in cache → attempt deploy → POST returns 400 (no retry): manifest not updated."""
         self.set_caches(
             public_cache={
                 "resources": "2",
@@ -333,7 +335,6 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
-        self.set_kudu_no_deployment()
         self.rest_client.post.return_value = MagicMock(status=400)
         self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
         self.set_current_function_apps(ALL_FUNCTIONS)
@@ -351,20 +352,19 @@ class TestDeployerTask(TaskTestCase):
             "scaling": "1",
             "diagnostic_settings": "1",
         }
-        self.set_caches(
-            public_cache=public_cache,
-            private_cache={
-                "resources": "1",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
+        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
+        # Pre-populate deployment_url on the .us domain
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/deployments/latest"},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         await self.run_deployer_task()
 
         self.credential.get_token.assert_awaited_once_with("https://management.usgovcloudapi.net/.default")
-        self.assertEqual(self.cache, public_cache)
+        self.assertEqual(self.cache["resources"].version, "2")
         # GET status was checked on the .us domain
         get_urls = [str(c) for c in self.rest_client.get.call_args_list]
         self.assertTrue(any("azurewebsites.us" in u for u in get_urls))
@@ -446,8 +446,6 @@ class TestDeployerTask(TaskTestCase):
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(["resources-task-0863329b4b49"])
-        self.set_kudu_no_deployment()
-        self.rest_client.post.return_value = MagicMock(status=202)
 
         def correct_settings(resource_group, function_app_name):
             return mock(properties={"WEBSITE_CONTENTSHARE": f"contentshare-{function_app_name}"})
@@ -469,8 +467,6 @@ class TestDeployerTask(TaskTestCase):
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
         self.set_current_function_apps(["resources-task-0863329b4b49"])
-        self.set_kudu_no_deployment()
-        self.rest_client.post.return_value = MagicMock(status=202)
 
         def correct_settings(resource_group, function_app_name):
             return mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49123412341234"})
@@ -519,11 +515,14 @@ class TestDeployerTask(TaskTestCase):
     # -------------------------------------------------------------------------
 
     async def test_upload_function_app_data_succeeds_on_202(self):
-        self.rest_client.post.return_value = MagicMock(status=202)
+        self.rest_client.post.return_value = MagicMock(
+            status=202,
+            headers={"Location": RESOURCES_STATUS_URL},
+        )
         task = DeployerTask()
-        # Should not raise
-        await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
+        poll_url = await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
         self.rest_client.post.assert_awaited_once()
+        self.assertEqual(poll_url, RESOURCES_STATUS_URL)
 
     async def test_upload_function_app_data_raises_on_non_202(self):
         self.rest_client.post.return_value = MagicMock(status=400, reason="Bad Request")
@@ -533,134 +532,177 @@ class TestDeployerTask(TaskTestCase):
             await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
         self.assertIn("expected 202, got 400", str(ctx.exception))
 
+    async def test_upload_function_app_data_raises_on_missing_location(self):
+        self.rest_client.post.return_value = MagicMock(status=202, headers={})
+        task = DeployerTask()
+        with self.assertRaises(DeployError) as ctx:
+            await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
+        self.assertIn("no Location header", str(ctx.exception))
+
     # -------------------------------------------------------------------------
-    # check_deployment_status tests
+    # get_deployment_status tests
     # -------------------------------------------------------------------------
 
-    async def test_check_deployment_status_in_progress(self):
+    async def test_get_deployment_status_in_progress(self):
         task = DeployerTask()
         for in_progress_status in [0, 1, 2]:
             self.rest_client.get.return_value.json = AsyncMock(
-                return_value={"complete": False, "status": in_progress_status}
+                return_value={"status": in_progress_status}
             )
-            is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
-            self.assertFalse(is_complete)
-            self.assertFalse(is_successful)
+            status = await task.get_deployment_status(RESOURCES_STATUS_URL)
+            self.assertEqual(status, in_progress_status)
 
-    async def test_check_deployment_status_success(self):
-        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
+    async def test_get_deployment_status_success(self):
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"status": 4})
         task = DeployerTask()
-        is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
-        self.assertTrue(is_complete)
-        self.assertTrue(is_successful)
+        status = await task.get_deployment_status(RESOURCES_STATUS_URL)
+        self.assertEqual(status, 4)
 
-    async def test_check_deployment_status_failed(self):
-        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 3})
+    async def test_get_deployment_status_failed(self):
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"status": 3})
         task = DeployerTask()
-        is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
-        self.assertTrue(is_complete)
-        self.assertFalse(is_successful)
+        status = await task.get_deployment_status(RESOURCES_STATUS_URL)
+        self.assertEqual(status, 3)
 
-    async def test_check_deployment_status_not_found(self):
-        """404 → no deployment exists, treat as (complete=True, successful=False) to trigger a new deploy."""
-        self.rest_client.get.return_value.ok = False
-        self.rest_client.get.return_value.status = 404
+    async def test_get_deployment_status_missing_status_field(self):
+        """Response missing 'status' field → DeployError."""
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True})
         task = DeployerTask()
-        is_complete, is_successful = await task.check_deployment_status(RESOURCES_STATUS_URL)
-        self.assertTrue(is_complete)
-        self.assertFalse(is_successful)
+        with self.assertRaises((DeployError, RetryError)):
+            await task.get_deployment_status(RESOURCES_STATUS_URL)
 
-    async def test_check_deployment_status_http_error(self):
+    async def test_get_deployment_status_http_error(self):
         self.rest_client.get.return_value.ok = False
         self.rest_client.get.return_value.status = 500
         self.rest_client.get.return_value.reason = "Internal Server Error"
         self.rest_client.get.return_value.content.read = AsyncMock(return_value=b"server error")
         task = DeployerTask()
-        with self.assertRaises(DeployError):
-            await task.check_deployment_status(RESOURCES_STATUS_URL)
+        with self.assertRaises((DeployError, RetryError)):
+            await task.get_deployment_status(RESOURCES_STATUS_URL)
 
     # -------------------------------------------------------------------------
     # deploy_component state machine tests
     # -------------------------------------------------------------------------
 
-    async def test_deploy_component_kudu_in_progress_skips(self):
-        """Deployment already in progress: no new deploy, manifest unchanged."""
+    async def test_deploy_starts_deployment(self):
+        """No deployment_url in cache: POST called, url stored in cache, version unchanged."""
         self.set_caches(
             public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
             private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
         )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+
+        task = await self.run_deployer_task()
+
+        zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
+        self.assertTrue(zip_calls)
+        self.assertEqual(task.manifest_cache["resources"].version, "1")
+        self.assertEqual(task.manifest_cache["resources"].deployment_url, RESOURCES_STATUS_URL)
+
+    async def test_deploy_polls_in_progress(self):
+        """Deployment URL in cache, GET returns in-progress: no new deploy, url preserved."""
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        ).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.set_kudu_in_progress()
 
         task = await self.run_deployer_task()
 
         self.rest_client.post.assert_not_awaited()
-        self.assertEqual(task.manifest_cache["resources"], "1")
+        self.assertEqual(task.manifest_cache["resources"].version, "1")
+        self.assertEqual(task.manifest_cache["resources"].deployment_url, RESOURCES_STATUS_URL)
         self.write_cache.assert_not_awaited()
 
-    async def test_deploy_component_kudu_success_syncs_and_updates_manifest(self):
-        """Kudu shows success: sync triggers, update manifest, no new zip deploy."""
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
+    async def test_deploy_polls_success(self):
+        """Deployment URL in cache, GET returns success: sync triggers, version updated, url cleared."""
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        ).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         task = await self.run_deployer_task()
 
         zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
         self.assertFalse(zip_calls)
-        self.assertEqual(task.manifest_cache["resources"], "2")
-        self.assertEqual(self.cache["resources"], "2")
+        self.assertEqual(task.manifest_cache["resources"].version, "2")
+        self.assertFalse(task.manifest_cache["resources"].deployment_url)
+        self.assertEqual(self.cache["resources"].version, "2")
 
-    async def test_deploy_component_kudu_failed_starts_new_deploy(self):
-        """Kudu shows failure: start a new deployment."""
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
+    async def test_deploy_polls_failure(self):
+        """Deployment URL in cache, GET returns failure: url cleared, version unchanged."""
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        ).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 3})
-        self.rest_client.post.return_value = MagicMock(status=202)
 
         task = await self.run_deployer_task()
 
         zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
-        self.assertTrue(zip_calls)
-        # Manifest not updated (deployment just started)
-        self.assertEqual(task.manifest_cache["resources"], "1")
-        self.write_cache.assert_not_awaited()
+        self.assertFalse(zip_calls)
+        self.assertEqual(task.manifest_cache["resources"].version, "1")
+        self.assertFalse(task.manifest_cache["resources"].deployment_url)
+        # Cache written to clear the url
+        self.write_cache.assert_awaited_once()
 
-    async def test_deploy_component_sync_triggers_fails_no_manifest_update(self):
-        """Sync triggers fails after Kudu success: manifest NOT updated."""
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_function_apps(ALL_FUNCTIONS)
-        # Kudu success, but sync triggers POST fails (all 5 retries)
-        self.rest_client.post.return_value = MagicMock(ok=False, status=500, reason="Error")
-        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
-
-        task = await self.run_deployer_task()
-
-        self.assertEqual(task.manifest_cache["resources"], "1")
-        self.write_cache.assert_not_awaited()
-
-    async def test_deploy_component_status_check_error_attempts_deploy(self):
-        """Kudu check raises DeployError (e.g. 500): fall through to attempting a new deployment."""
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
+    async def test_deploy_polls_error(self):
+        """Deployment URL in cache, GET raises DeployError: url preserved, retry next run."""
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        ).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
         self.set_current_function_apps(ALL_FUNCTIONS)
         self.rest_client.get.return_value.ok = False
         self.rest_client.get.return_value.status = 500
         self.rest_client.get.return_value.reason = "Error"
         self.rest_client.get.return_value.content.read = AsyncMock(return_value=b"")
-        self.rest_client.post.return_value = MagicMock(status=202)
 
-        await self.run_deployer_task()
+        task = await self.run_deployer_task()
 
+        # URL preserved — no new deploy started, no cache write
         zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
-        self.assertTrue(zip_calls)
+        self.assertFalse(zip_calls)
+        self.assertEqual(task.manifest_cache["resources"].deployment_url, RESOURCES_STATUS_URL)
+        self.write_cache.assert_not_awaited()
+
+    async def test_sync_triggers_failure(self):
+        """Poll success, sync triggers fails: url preserved so next run retries sync."""
+        self.public_client.download_blob.return_value.readall.return_value = dumps(
+            {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        ).encode()
+        self.read_private_cache.return_value = dumps({
+            "resources": {"version": "1", "deployment_url": RESOURCES_STATUS_URL},
+            "scaling": {"version": "1"},
+            "diagnostic_settings": {"version": "1"},
+        })
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        # Kudu success, but sync triggers POST fails (all retries)
+        self.rest_client.post.return_value = MagicMock(ok=False, status=500, reason="Error")
+        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
+
+        task = await self.run_deployer_task()
+
+        self.assertEqual(task.manifest_cache["resources"].version, "1")
+        # Deployment URL preserved — next run polls status and retries sync
+        self.assertEqual(task.manifest_cache["resources"].deployment_url, RESOURCES_STATUS_URL)
+        self.write_cache.assert_not_awaited()

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -17,8 +17,15 @@ from cache.env import (
     RESOURCE_GROUP_SETTING,
     SUBSCRIPTION_ID_SETTING,
 )
-from cache.manifest_cache import MANIFEST_CACHE_NAME, ManifestCache, deserialize_manifest_cache
-from tasks.deployer_task import DEPLOYER_TASK_NAME, DeployerTask
+from cache.manifest_cache import (
+    MANIFEST_CACHE_NAME,
+    PENDING_DEPLOYMENTS_CACHE_NAME,
+    ManifestCache,
+    PendingDeployment,
+    deserialize_manifest_cache,
+    deserialize_pending_deployments,
+)
+from tasks.deployer_task import DEPLOYER_TASK_NAME, DeployError, DeployerTask
 from tasks.tests.common import AsyncMockClient, TaskTestCase, async_generator, mock
 from tasks.version import VERSION
 
@@ -28,6 +35,16 @@ ALL_FUNCTIONS = [
     "diagnostic-settings-task-0863329b4b49",
 ]
 
+RESOURCES_POLL_URL = "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
+SCALING_POLL_URL = "https://scaling-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
+DS_POLL_URL = "https://diagnostic-settings-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
+
+
+def make_pending_state(*pending: PendingDeployment) -> str:
+    return dumps({p.component: {"component": p.component, "function_app": p.function_app,
+                                "poll_url": p.poll_url, "target_manifest_hash": p.target_manifest_hash}
+                  for p in pending})
+
 
 class TestDeployerTask(TaskTestCase):
     TASK_NAME = DEPLOYER_TASK_NAME
@@ -35,6 +52,10 @@ class TestDeployerTask(TaskTestCase):
     @property
     def cache(self) -> ManifestCache:
         return self.cache_value(MANIFEST_CACHE_NAME, deserialize_manifest_cache)
+
+    @property
+    def pending_cache(self):
+        return self.cache_value(PENDING_DEPLOYMENTS_CACHE_NAME, deserialize_pending_deployments)
 
     def setUp(self) -> None:
         super().setUp()
@@ -51,7 +72,12 @@ class TestDeployerTask(TaskTestCase):
         self.patch("ContainerClient").return_value = self.public_client
         self.read_private_cache = self.patch("read_cache")
         self.rest_client = AsyncMockClient()
-        self.rest_client.post.return_value = MagicMock()
+        self.rest_client.post.return_value = MagicMock(
+            status=202,
+            headers={"Location": RESOURCES_POLL_URL},
+        )
+        self.rest_client.get.return_value.ok = True
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
         self.patch("ClientSession").return_value = self.rest_client
         self.web_client = AsyncMockClient()
         self.web_client.web_apps.list_by_resource_group = MagicMock(return_value=async_generator())
@@ -71,10 +97,14 @@ class TestDeployerTask(TaskTestCase):
             *(mock(name=app) for app in function_apps)
         )
 
-    async def run_deployer_task(self) -> DeployerTask:
-        async with DeployerTask(is_initial_run=False) as task:
+    async def run_deployer_task(self, pending_deployments_state: str = "") -> DeployerTask:
+        async with DeployerTask(pending_deployments_state, is_initial_run=False) as task:
             await task.run()
         return task
+
+    # -------------------------------------------------------------------------
+    # Existing integration tests
+    # -------------------------------------------------------------------------
 
     async def test_deploy_task_no_diff(self):
         self.set_caches(
@@ -95,7 +125,8 @@ class TestDeployerTask(TaskTestCase):
 
         self.write_cache.assert_not_awaited()
 
-    async def test_deploy_task_diff_func_app(self):
+    async def test_deploy_task_starts_async_deploy(self):
+        """First run with a diff: starts async deploy, writes pending, does NOT update manifest."""
         public_cache: ManifestCache = {
             "resources": "2",
             "scaling": "1",
@@ -113,11 +144,44 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.assertEqual(self.cache, public_cache)
+        # async URL used
         self.assertEqual(
             self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy?isAsync=true",
         )
+        # pending written, manifest NOT written
+        pending = self.pending_cache
+        self.assertIn("resources", pending)
+        self.assertEqual(pending["resources"].target_manifest_hash, "2")
+        manifest_written_calls = [c for c in self.write_cache.call_args_list if c.args[0] == MANIFEST_CACHE_NAME]
+        self.assertFalse(manifest_written_calls)
+
+    async def test_deploy_task_diff_func_app(self):
+        """Second run (pending exists): completes deploy, updates manifest."""
+        public_cache: ManifestCache = {
+            "resources": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
+        }
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={
+                "resources": "1",
+                "scaling": "1",
+                "diagnostic_settings": "1",
+            },
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
+
+        await self.run_deployer_task(pending_state)
+
+        self.assertEqual(self.cache, public_cache)
+        # sync_function_app_triggers uses POST; no zip deploy POST
+        zip_calls = [c for c in self.rest_client.post.call_args_list if "zipdeploy" in str(c)]
+        self.assertFalse(zip_calls)
 
     async def test_deploy_task_diff_func_and_container_app(self):
         public_cache: ManifestCache = {
@@ -134,14 +198,13 @@ class TestDeployerTask(TaskTestCase):
             },
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
 
-        await self.run_deployer_task()
+        await self.run_deployer_task(pending_state)
 
         self.assertEqual(self.cache, public_cache)
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
-        )
 
     async def test_partial_success_func_app(self):
         self.set_caches(
@@ -165,12 +228,14 @@ class TestDeployerTask(TaskTestCase):
 
         self.public_client.download_blob.side_effect = _download_blob
 
-        await self.run_deployer_task()
-
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+        # Pre-populate resources pending; diagnostic_settings will fail to start again this run
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
         )
+
+        await self.run_deployer_task(pending_state)
+
+        # resources completed, diagnostic_settings failed → only resources updated
         self.assertEqual(
             self.cache,
             {
@@ -179,11 +244,10 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
+        # diagnostic_settings download was retried 5 times
         self.public_client.download_blob.assert_has_calls(
             [
                 call("manifest.json"),
-                call().readall(),
-                call("resources_task.zip"),
                 call().readall(),
                 call("diagnostic_settings_task.zip"),
                 call("diagnostic_settings_task.zip"),
@@ -215,18 +279,22 @@ class TestDeployerTask(TaskTestCase):
     async def test_deploy_task_no_private_manifests(self):
         public_cache: ManifestCache = {
             "resources": "2",
-            "scaling": "1",
-            "diagnostic_settings": "1",
+            "scaling": "2",
+            "diagnostic_settings": "2",
         }
         self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
         self.read_private_cache.return_value = ""
         self.set_current_function_apps(ALL_FUNCTIONS)
 
-        await self.run_deployer_task()
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2"),
+            PendingDeployment("scaling", "scaling-task-0863329b4b49", SCALING_POLL_URL, "2"),
+            PendingDeployment("diagnostic_settings", "diagnostic-settings-task-0863329b4b49", DS_POLL_URL, "2"),
+        )
 
-        public_cache_str = dumps(public_cache)
+        await self.run_deployer_task(pending_state)
 
-        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
+        self.assertEqual(self.cache, public_cache)
 
     async def test_deploy_task_no_manifests(self):
         self.public_client.download_blob.return_value.readall.return_value = b""
@@ -243,19 +311,23 @@ class TestDeployerTask(TaskTestCase):
     async def test_deploy_task_private_manifest_retry_error(self):
         public_cache: ManifestCache = {
             "resources": "2",
-            "scaling": "1",
-            "diagnostic_settings": "1",
+            "scaling": "2",
+            "diagnostic_settings": "2",
         }
         self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
         self.read_private_cache.side_effect = HttpResponseError
         self.set_current_function_apps(ALL_FUNCTIONS)
 
-        await self.run_deployer_task()
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2"),
+            PendingDeployment("scaling", "scaling-task-0863329b4b49", SCALING_POLL_URL, "2"),
+            PendingDeployment("diagnostic_settings", "diagnostic-settings-task-0863329b4b49", DS_POLL_URL, "2"),
+        )
 
-        public_cache_str = dumps(public_cache)
+        await self.run_deployer_task(pending_state)
 
         self.assertEqual(self.read_private_cache.await_count, 5)
-        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
+        self.assertEqual(self.cache, public_cache)
 
     async def test_post_func_app_fails(self):
         self.set_caches(
@@ -270,22 +342,24 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
-        self.rest_client.post.return_value.ok = False
+        self.rest_client.post.return_value = MagicMock(status=400)
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         await self.run_deployer_task()
 
         self.write_cache.assert_not_awaited()
-        self.assertEqual(self.rest_client.post.await_count, 5)
+        # No retry on zip deploy
+        self.assertEqual(self.rest_client.post.await_count, 1)
 
     async def test_deploy_task_govcloud(self):
         self.env[CONTROL_PLANE_REGION_SETTING] = "usgovarizona"
+        public_cache: ManifestCache = {
+            "resources": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
+        }
         self.set_caches(
-            public_cache={
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
+            public_cache=public_cache,
             private_cache={
                 "resources": "1",
                 "scaling": "1",
@@ -293,23 +367,16 @@ class TestDeployerTask(TaskTestCase):
             },
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
+        gov_poll_url = "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/deployments/latest"
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", gov_poll_url, "2")
+        )
 
-        await self.run_deployer_task()
+        await self.run_deployer_task(pending_state)
 
         self.credential.get_token.assert_awaited_once_with("https://management.usgovcloudapi.net/.default")
 
-        self.assertEqual(
-            self.cache,
-            {
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/zipdeploy",
-        )
+        self.assertEqual(self.cache, public_cache)
 
     async def test_fix_content_share__fixes_wrong_value(self):
         wrong_settings = mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49"})
@@ -353,7 +420,7 @@ class TestDeployerTask(TaskTestCase):
 
         self.assertFalse(result)
         self.web_client.web_apps.update_application_settings.assert_not_awaited()
-    
+
     async def test_fix_content_share__skips_python_script_value(self):
         correct_settings = mock(properties={"WEBSITE_CONTENTSHARE": "resources-task-0863329b4b49123412341234"})
         self.web_client.web_apps.list_application_settings = AsyncMock(return_value=correct_settings)
@@ -400,7 +467,7 @@ class TestDeployerTask(TaskTestCase):
         self.web_client.web_apps.update_application_settings.assert_not_awaited()
         self.assertEqual(
             self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy?isAsync=true",
         )
 
     async def test_deploy_proceeds_when_content_share_is_python_script_value(self):
@@ -421,7 +488,7 @@ class TestDeployerTask(TaskTestCase):
         self.web_client.web_apps.update_application_settings.assert_not_awaited()
         self.assertEqual(
             self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy?isAsync=true",
         )
 
     async def test_deployer_tags(self):
@@ -451,3 +518,217 @@ class TestDeployerTask(TaskTestCase):
                 f"version:{VERSION}",
             ],
         )
+
+    # -------------------------------------------------------------------------
+    # upload_function_app_data tests
+    # -------------------------------------------------------------------------
+
+    async def test_upload_function_app_data_returns_poll_url(self):
+        poll_url = "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/deployments/latest"
+        self.rest_client.post.return_value = MagicMock(
+            status=202,
+            headers={"Location": poll_url},
+        )
+        task = DeployerTask()
+        result = await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
+        self.assertEqual(result, poll_url)
+
+    async def test_upload_function_app_data_raises_on_non_202(self):
+        self.rest_client.post.return_value = MagicMock(
+            status=400,
+            reason="Bad Request",
+        )
+        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"error body")
+        task = DeployerTask()
+        with self.assertRaises(DeployError) as ctx:
+            await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
+        self.assertIn("expected 202, got 400", str(ctx.exception))
+
+    async def test_upload_function_app_data_raises_on_missing_location(self):
+        self.rest_client.post.return_value = MagicMock(
+            status=202,
+            headers={},
+        )
+        task = DeployerTask()
+        with self.assertRaises(DeployError) as ctx:
+            await task.upload_function_app_data("resources-task-0863329b4b49", b"data")
+        self.assertIn("no Location header", str(ctx.exception))
+
+    # -------------------------------------------------------------------------
+    # check_deployment_status tests
+    # -------------------------------------------------------------------------
+
+    async def test_check_deployment_status_in_progress(self):
+        task = DeployerTask()
+        for in_progress_status in [0, 1, 2]:
+            self.rest_client.get.return_value.json = AsyncMock(
+                return_value={"complete": False, "status": in_progress_status}
+            )
+            is_complete, is_successful = await task.check_deployment_status(RESOURCES_POLL_URL)
+            self.assertFalse(is_complete)
+            self.assertFalse(is_successful)
+
+    async def test_check_deployment_status_success(self):
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
+        task = DeployerTask()
+        is_complete, is_successful = await task.check_deployment_status(RESOURCES_POLL_URL)
+        self.assertTrue(is_complete)
+        self.assertTrue(is_successful)
+
+    async def test_check_deployment_status_failed(self):
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 3})
+        task = DeployerTask()
+        is_complete, is_successful = await task.check_deployment_status(RESOURCES_POLL_URL)
+        self.assertTrue(is_complete)
+        self.assertFalse(is_successful)
+
+    async def test_check_deployment_status_http_error(self):
+        self.rest_client.get.return_value.ok = False
+        self.rest_client.get.return_value.status = 500
+        self.rest_client.get.return_value.reason = "Internal Server Error"
+        self.rest_client.get.return_value.content.read = AsyncMock(return_value=b"server error")
+        task = DeployerTask()
+        with self.assertRaises(DeployError):
+            await task.check_deployment_status(RESOURCES_POLL_URL)
+
+    # -------------------------------------------------------------------------
+    # deploy_component state machine tests
+    # -------------------------------------------------------------------------
+
+    async def test_deploy_component_no_pending_starts_deploy(self):
+        """No pending deployment: starts async deploy, populates pending_deployments, does NOT sync or update manifest."""
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+
+        task = await self.run_deployer_task()
+
+        self.rest_client.post.assert_awaited_once()
+        self.rest_client.get.assert_not_awaited()
+        # sync triggers was NOT called (only POST to zipdeploy)
+        post_url = self.rest_client.post.call_args[0][0]
+        self.assertIn("zipdeploy?isAsync=true", post_url)
+        # pending_deployments written
+        pending = self.pending_cache
+        self.assertIn("resources", pending)
+        # manifest NOT updated
+        self.assertEqual(task.manifest_cache["resources"], "1")
+
+    async def test_deploy_component_pending_in_progress(self):
+        """Pending deployment still in progress: no new POST, preserves pending."""
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": False, "status": 1})
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
+
+        task = await self.run_deployer_task(pending_state)
+
+        self.rest_client.post.assert_not_awaited()
+        self.rest_client.get.assert_awaited_once()
+        # pending preserved (still in pending_deployments)
+        self.assertIn("resources", task.pending_deployments)
+        # manifest NOT updated
+        self.assertEqual(task.manifest_cache["resources"], "1")
+        # Nothing written (pending unchanged from initial state)
+        self.write_cache.assert_not_awaited()
+
+    async def test_deploy_component_pending_succeeds(self):
+        """Pending deployment succeeds: syncs triggers, updates manifest, clears pending."""
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
+
+        task = await self.run_deployer_task(pending_state)
+
+        self.rest_client.post.assert_awaited()  # sync triggers calls POST
+        self.rest_client.get.assert_awaited_once()
+        self.assertNotIn("resources", task.pending_deployments)
+        self.assertEqual(task.manifest_cache["resources"], "2")
+        self.assertEqual(self.cache, public_cache)
+
+    async def test_deploy_component_pending_fails(self):
+        """Pending deployment fails: clears pending, does NOT update manifest."""
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 3})
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
+
+        task = await self.run_deployer_task(pending_state)
+
+        self.assertNotIn("resources", task.pending_deployments)
+        self.assertEqual(task.manifest_cache["resources"], "1")
+        # manifest NOT written (unchanged), pending IS written (cleared)
+        pending_written_calls = [c for c in self.write_cache.call_args_list
+                                 if c.args[0] == PENDING_DEPLOYMENTS_CACHE_NAME]
+        self.assertTrue(pending_written_calls)
+        manifest_written_calls = [c for c in self.write_cache.call_args_list
+                                   if c.args[0] == MANIFEST_CACHE_NAME]
+        self.assertFalse(manifest_written_calls)
+
+    async def test_deploy_component_status_check_error_preserves_pending(self):
+        """Status check HTTP error: preserves pending, does not crash."""
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.rest_client.get.return_value.ok = False
+        self.rest_client.get.return_value.status = 500
+        self.rest_client.get.return_value.reason = "Server Error"
+        self.rest_client.get.return_value.content.read = AsyncMock(return_value=b"")
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
+
+        task = await self.run_deployer_task(pending_state)
+
+        # Pending preserved
+        self.assertIn("resources", task.pending_deployments)
+        # Nothing written
+        self.write_cache.assert_not_awaited()
+
+    async def test_deploy_component_sync_triggers_fails_no_manifest_update(self):
+        """Sync triggers fails after successful deploy: manifest NOT updated, pending cleared."""
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.set_caches(
+            public_cache=public_cache,
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+        self.rest_client.get.return_value.json = AsyncMock(return_value={"complete": True, "status": 4})
+        # sync triggers POST fails (all 5 retries)
+        self.rest_client.post.return_value = MagicMock(ok=False, status=500, reason="Error")
+        self.rest_client.post.return_value.content.read = AsyncMock(return_value=b"")
+        pending_state = make_pending_state(
+            PendingDeployment("resources", "resources-task-0863329b4b49", RESOURCES_POLL_URL, "2")
+        )
+
+        task = await self.run_deployer_task(pending_state)
+
+        # Pending cleared (deployment completed, even though triggers failed)
+        self.assertNotIn("resources", task.pending_deployments)
+        # Manifest NOT updated
+        self.assertEqual(task.manifest_cache["resources"], "1")


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue:

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [ ] I have verified that this change is backwards compatible.
