### PR TITLE
fix: Pre-create QA managed env with workload profiles

### DIFF
--- a/ci/scripts/deploy/deploy_qa_env.sh
+++ b/ci/scripts/deploy/deploy_qa_env.sh
@@ -18,6 +18,21 @@ az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --t
 
 resource_group=lfoqaenv
 
+# Azure ARM can't create managed environments with workload profiles (known limitation).
+# Pre-create via CLI if the env doesn't exist or lacks workload profiles.
+ENV_NAME="dd-log-forwarder-env-db751049441a-eastus"
+wp=$(az containerapp env show --name "$ENV_NAME" --resource-group "$resource_group" \
+     --query "properties.workloadProfiles[0].name" -o tsv 2>/dev/null || echo "")
+if [ -z "$wp" ]; then
+  echo "Creating managed environment with workload profiles..."
+  az containerapp job list --resource-group "$resource_group" \
+    --query "[?ends_with(properties.environmentId, '$ENV_NAME')].name" -o tsv | \
+    xargs -I{} az containerapp job delete --name {} --resource-group "$resource_group" --yes 2>/dev/null || true
+  az containerapp env delete --name "$ENV_NAME" --resource-group "$resource_group" --yes 2>/dev/null || true
+  az containerapp env create --name "$ENV_NAME" --resource-group "$resource_group" \
+    --location eastus --enable-workload-profiles
+fi
+
 : deploy to resource group $resource_group
 echo "Deploying $resource_group, view progress at https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id/%2Fproviders%2FMicrosoft.Management%2FmanagementGroups%2FAzure-Integrations-Mg%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2F$resource_group"
 az deployment mg create --management-group-id "Azure-Integrations-Mg" \


### PR DESCRIPTION
## Summary

- Azure ARM/Bicep can't create `managedEnvironments` with workload profiles — the resource gets created without them, then fails trying to add them ([known limitation](https://github.com/DataDog/integrations-management/commit/794a6e8), hit previously in Nov 2025)
- Commit `84bd9c0` in `integrations-management` re-added workload profiles to the Bicep, breaking the QA deploy pipeline
- Adds a pre-flight check to `deploy_qa_env.sh` that ensures the managed environment exists with workload profiles (via `az containerapp env create --enable-workload-profiles`) before the Bicep deployment runs

## Test plan

- [x] Manually recreated the QA environment with `--enable-workload-profiles` and confirmed `workloadProfiles` is populated
- [ ] Re-run `deploy-qa-env` pipeline to confirm end-to-end success
- [ ] Verify deployer job is recreated and running on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)