### PR TITLE
Fix deployer skipping initial deployments

### DIFF
--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -116,12 +116,7 @@ class DeployerTask(Task):
         ).copy()
 
         if not private_manifest:
-            await gather(
-                *[
-                    self.deploy_component(component, current_function_app_ids)
-                    for component in public_manifest
-                ]
-            )
+            await gather(*[self.deploy_component(component, current_function_app_ids) for component in public_manifest])
         else:
             self.log.info("Private manifest exists, skipping deployment")
 

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -26,6 +26,7 @@ from cache.env import (
     get_config_option,
 )
 from cache.manifest_cache import (
+    KEY_TO_ZIP,
     MANIFEST_FILE_NAME,
     PUBLIC_STORAGE_ACCOUNT_URL,
     TASKS_CONTAINER,
@@ -39,6 +40,7 @@ from tasks.common import (
     SCALING_TASK_PREFIX,
     Resource,
     get_azure_mgmt_url,
+    is_azure_gov,
 )
 from tasks.concurrency import collect
 from tasks.task import Task, task_main
@@ -48,6 +50,10 @@ DEPLOYER_TASK_NAME = "deployer_task"
 
 MAX_ATTEMPTS = 5
 MAX_WAIT_TIME = 30
+
+
+class DeployError(Exception):
+    pass
 
 
 class DeployerTask(Task):
@@ -154,11 +160,46 @@ class DeployerTask(Task):
         if not function_app:
             self.log.error(f"Function app for {component} not found in {current_function_app_ids}, skipping deployment")
             return
-        self.log.info(f"Skipping deployment for {function_app}; zip deploy and trigger sync are disabled")
-        self.log.info(f"Leaving manifest cache unchanged for {component}")
+        try:
+            self.log.info(f"Downloading function app data for {component}")
+            zip_data = await self.download_function_app_data(component)
+            self.log.info(f"Deploying {function_app}")
+            await self.upload_function_app_data(function_app, zip_data)
+            await self.sync_function_app_triggers(function_app)
+        except Exception:
+            self.log.exception(f"Failed to deploy {component}")
+            return
+        self.manifest_cache[component] = self.public_manifest[component]
+        self.log.info(f"Finished deploying {component}")
+
+    @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
+    async def upload_function_app_data(self, function_app_name: str, function_app_data: bytes) -> None:
+        function_app_url = "https://{}.scm.azurewebsites.{}/api/zipdeploy".format(
+            function_app_name, "us" if is_azure_gov(self.region) else "net"
+        )
+        resp = await self.rest_client.post(function_app_url, data=function_app_data)
+        if not resp.ok:
+            content = (await resp.content.read()).decode()
+            raise DeployError(f"Failed to upload function app data: {resp.status} ({resp.reason})\n{content}")
+
+    @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
+    async def sync_function_app_triggers(self, function_app_name: str) -> None:
+        resp = await self.rest_client.post(
+            f"{get_azure_mgmt_url(self.region)}/subscriptions/{self.subscription_id}/resourceGroups/{self.resource_group}/providers/Microsoft.Web/sites/{function_app_name}/syncfunctiontriggers?api-version=2016-08-01"
+        )
+        if not resp.ok:
+            content = (await resp.content.read()).decode()
+            raise DeployError(f"Failed to sync function app triggers: {resp.status} ({resp.reason})\n{content}")
+
+    @retry(stop=stop_after_attempt(MAX_ATTEMPTS))
+    async def download_function_app_data(self, component: ControlPlaneComponent) -> bytes:
+        blob_name = KEY_TO_ZIP[component]
+        stream = await self.public_storage_client.download_blob(blob_name)
+        app_data = await stream.readall()
+        return app_data
 
     async def write_caches(self) -> None:
-        if self.private_manifest is None or self.manifest_cache == self.private_manifest:
+        if self.manifest_cache == self.private_manifest:
             return
         await write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache))
 

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -115,13 +115,15 @@ class DeployerTask(Task):
             }
         ).copy()
 
-        await gather(
-            *[
-                self.deploy_component(component, current_function_app_ids)
-                for component in public_manifest
-                if not private_manifest or public_manifest[component] != private_manifest[component]
-            ]
-        )
+        if not private_manifest:
+            await gather(
+                *[
+                    self.deploy_component(component, current_function_app_ids)
+                    for component in public_manifest
+                ]
+            )
+        else:
+            self.log.info("Private manifest exists, skipping deployment")
 
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS), retry=retry_if_not_exception_type(InvalidCacheError))
     async def get_public_manifests(self) -> ManifestCache:

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from json import dumps
-from unittest.mock import MagicMock
+from unittest.mock import DEFAULT, MagicMock, call
 
 # 3p
 from azure.core.exceptions import HttpResponseError
@@ -92,12 +92,13 @@ class TestDeployerTask(TaskTestCase):
         self.write_cache.assert_not_awaited()
 
     async def test_deploy_task_diff_func_app(self):
+        public_cache: ManifestCache = {
+            "resources": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
+        }
         self.set_caches(
-            public_cache={
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
+            public_cache=public_cache,
             private_cache={
                 "resources": "1",
                 "scaling": "1",
@@ -108,16 +109,20 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.write_cache.assert_not_awaited()
-        self.rest_client.post.assert_not_awaited()
+        self.assertEqual(self.cache, public_cache)
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+        )
 
     async def test_deploy_task_diff_func_and_container_app(self):
+        public_cache: ManifestCache = {
+            "resources": "2",
+            "scaling": "1",
+            "diagnostic_settings": "1",
+        }
         self.set_caches(
-            public_cache={
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
+            public_cache=public_cache,
             private_cache={
                 "resources": "1",
                 "scaling": "1",
@@ -128,8 +133,11 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.write_cache.assert_not_awaited()
-        self.rest_client.post.assert_not_awaited()
+        self.assertEqual(self.cache, public_cache)
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+        )
 
     async def test_partial_success_func_app(self):
         self.set_caches(
@@ -144,17 +152,43 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
-        self.set_current_function_apps(
-            [
-                "resources-task-0863329b4b49",
-                "scaling-task-0863329b4b49",
-            ]
-        )
+        self.set_current_function_apps(ALL_FUNCTIONS)
+
+        def _download_blob(item: str):
+            if item == "diagnostic_settings_task.zip":
+                raise HttpResponseError()
+            return DEFAULT
+
+        self.public_client.download_blob.side_effect = _download_blob
 
         await self.run_deployer_task()
 
-        self.rest_client.post.assert_not_awaited()
-        self.write_cache.assert_not_awaited()
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
+        )
+        self.assertEqual(
+            self.cache,
+            {
+                "resources": "2",
+                "scaling": "1",
+                "diagnostic_settings": "1",
+            },
+        )
+        self.public_client.download_blob.assert_has_calls(
+            [
+                call("manifest.json"),
+                call().readall(),
+                call("resources_task.zip"),
+                call().readall(),
+                call("diagnostic_settings_task.zip"),
+                call("diagnostic_settings_task.zip"),
+                call("diagnostic_settings_task.zip"),
+                call("diagnostic_settings_task.zip"),
+                call("diagnostic_settings_task.zip"),
+            ],
+            any_order=True,
+        )
 
     async def test_deploy_task_no_public_manifest(self):
         self.public_client.download_blob.return_value.readall.return_value = b"invalid"
@@ -186,7 +220,9 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.write_cache.assert_not_awaited()
+        public_cache_str = dumps(public_cache)
+
+        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
 
     async def test_deploy_task_no_manifests(self):
         self.public_client.download_blob.return_value.readall.return_value = b""
@@ -212,10 +248,12 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.assertEqual(self.read_private_cache.await_count, 5)
-        self.write_cache.assert_not_awaited()
+        public_cache_str = dumps(public_cache)
 
-    async def test_deploy_task_does_not_post_to_function_apps(self):
+        self.assertEqual(self.read_private_cache.await_count, 5)
+        self.write_cache.assert_awaited_once_with("manifest.json", public_cache_str)
+
+    async def test_post_func_app_fails(self):
         self.set_caches(
             public_cache={
                 "resources": "2",
@@ -228,12 +266,13 @@ class TestDeployerTask(TaskTestCase):
                 "diagnostic_settings": "1",
             },
         )
+        self.rest_client.post.return_value.ok = False
         self.set_current_function_apps(ALL_FUNCTIONS)
 
         await self.run_deployer_task()
 
-        self.rest_client.post.assert_not_awaited()
         self.write_cache.assert_not_awaited()
+        self.assertEqual(self.rest_client.post.await_count, 5)
 
     async def test_deploy_task_govcloud(self):
         self.env[CONTROL_PLANE_REGION_SETTING] = "usgovarizona"
@@ -254,8 +293,19 @@ class TestDeployerTask(TaskTestCase):
         await self.run_deployer_task()
 
         self.credential.get_token.assert_awaited_once_with("https://management.usgovcloudapi.net/.default")
-        self.rest_client.post.assert_not_awaited()
-        self.write_cache.assert_not_awaited()
+
+        self.assertEqual(
+            self.cache,
+            {
+                "resources": "2",
+                "scaling": "1",
+                "diagnostic_settings": "1",
+            },
+        )
+        self.assertEqual(
+            self.rest_client.post.mock_calls[0][1][0],
+            "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/zipdeploy",
+        )
 
     async def test_deployer_tags(self):
         self.env[CONTROL_PLANE_ID_SETTING] = "a2b4c5d6"

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from json import dumps
-from unittest.mock import DEFAULT, MagicMock, call
+from unittest.mock import MagicMock
 
 # 3p
 from azure.core.exceptions import HttpResponseError
@@ -92,13 +92,12 @@ class TestDeployerTask(TaskTestCase):
         self.write_cache.assert_not_awaited()
 
     async def test_deploy_task_diff_func_app(self):
-        public_cache: ManifestCache = {
-            "resources": "2",
-            "scaling": "1",
-            "diagnostic_settings": "1",
-        }
         self.set_caches(
-            public_cache=public_cache,
+            public_cache={
+                "resources": "2",
+                "scaling": "1",
+                "diagnostic_settings": "1",
+            },
             private_cache={
                 "resources": "1",
                 "scaling": "1",
@@ -109,20 +108,16 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.assertEqual(self.cache, public_cache)
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
-        )
+        self.write_cache.assert_not_awaited()
+        self.rest_client.post.assert_not_awaited()
 
     async def test_deploy_task_diff_func_and_container_app(self):
-        public_cache: ManifestCache = {
-            "resources": "2",
-            "scaling": "1",
-            "diagnostic_settings": "1",
-        }
         self.set_caches(
-            public_cache=public_cache,
+            public_cache={
+                "resources": "2",
+                "scaling": "1",
+                "diagnostic_settings": "1",
+            },
             private_cache={
                 "resources": "1",
                 "scaling": "1",
@@ -133,11 +128,8 @@ class TestDeployerTask(TaskTestCase):
 
         await self.run_deployer_task()
 
-        self.assertEqual(self.cache, public_cache)
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
-        )
+        self.write_cache.assert_not_awaited()
+        self.rest_client.post.assert_not_awaited()
 
     async def test_partial_success_func_app(self):
         self.set_caches(
@@ -154,41 +146,10 @@ class TestDeployerTask(TaskTestCase):
         )
         self.set_current_function_apps(ALL_FUNCTIONS)
 
-        def _download_blob(item: str):
-            if item == "diagnostic_settings_task.zip":
-                raise HttpResponseError()
-            return DEFAULT
-
-        self.public_client.download_blob.side_effect = _download_blob
-
         await self.run_deployer_task()
 
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.net/api/zipdeploy",
-        )
-        self.assertEqual(
-            self.cache,
-            {
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
-        self.public_client.download_blob.assert_has_calls(
-            [
-                call("manifest.json"),
-                call().readall(),
-                call("resources_task.zip"),
-                call().readall(),
-                call("diagnostic_settings_task.zip"),
-                call("diagnostic_settings_task.zip"),
-                call("diagnostic_settings_task.zip"),
-                call("diagnostic_settings_task.zip"),
-                call("diagnostic_settings_task.zip"),
-            ],
-            any_order=True,
-        )
+        self.rest_client.post.assert_not_awaited()
+        self.write_cache.assert_not_awaited()
 
     async def test_deploy_task_no_public_manifest(self):
         self.public_client.download_blob.return_value.readall.return_value = b"invalid"
@@ -272,7 +233,7 @@ class TestDeployerTask(TaskTestCase):
         await self.run_deployer_task()
 
         self.write_cache.assert_not_awaited()
-        self.assertEqual(self.rest_client.post.await_count, 5)
+        self.rest_client.post.assert_not_awaited()
 
     async def test_deploy_task_govcloud(self):
         self.env[CONTROL_PLANE_REGION_SETTING] = "usgovarizona"
@@ -293,19 +254,8 @@ class TestDeployerTask(TaskTestCase):
         await self.run_deployer_task()
 
         self.credential.get_token.assert_awaited_once_with("https://management.usgovcloudapi.net/.default")
-
-        self.assertEqual(
-            self.cache,
-            {
-                "resources": "2",
-                "scaling": "1",
-                "diagnostic_settings": "1",
-            },
-        )
-        self.assertEqual(
-            self.rest_client.post.mock_calls[0][1][0],
-            "https://resources-task-0863329b4b49.scm.azurewebsites.us/api/zipdeploy",
-        )
+        self.write_cache.assert_not_awaited()
+        self.rest_client.post.assert_not_awaited()
 
     async def test_deployer_tags(self):
         self.env[CONTROL_PLANE_ID_SETTING] = "a2b4c5d6"


### PR DESCRIPTION
Fix bug in the deployer introduced in https://github.com/DataDog/azure-log-forwarding-orchestration/pull/483. We intended to skip the deployer _updating_ the control plane apps, but had disabled all deployments including the initial deploy.

- Revert commit 26f7c4f67d60535fb82d116ec3b84ccecd5df6ac.
- Modifies the deployer to only deploy initially (when the private manifest is empty).

## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue:

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Deployed an environment and checked that the initial deployer run succeeded: 
<img width="1060" height="359" alt="Screenshot 2026-04-10 at 4 23 36 PM" src="https://github.com/user-attachments/assets/a3cc9d46-e56e-415b-ab8d-91733de8bce5" />

Then subsequent deploys skipped:
<img width="1059" height="143" alt="Screenshot 2026-04-10 at 4 29 04 PM" src="https://github.com/user-attachments/assets/ff6f284d-95f1-43e8-9520-e082fb339e3b" />


## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
