### PR TITLE
[CLOUDS-6990] Pass base_url to remaining Azure SDK clients for Azure Government

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -86,6 +86,7 @@ from tasks.common import (
     FORWARDER_METRIC_PREFIX,
     FORWARDER_STORAGE_ACCOUNT_PREFIX,
     Resource,
+    get_azure_mgmt_url,
     get_container_app_name,
     get_managed_env_id,
     get_managed_env_name,
@@ -162,8 +163,9 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
         self.resource_group = resource_group
         self.subscription_id = subscription_id
         self.pii_rules_json = pii_rules_json
-        self.container_apps_client = ContainerAppsAPIClient(credential, subscription_id)
-        self.storage_client = StorageManagementClient(credential, subscription_id)
+        base_url = get_azure_mgmt_url(self.control_plane_region)
+        self.container_apps_client = ContainerAppsAPIClient(credential, subscription_id, base_url=base_url)
+        self.storage_client = StorageManagementClient(credential, subscription_id, base_url=base_url)
         self._blob_forwarder_data_lock = Lock()
         self._blob_forwarder_data: bytes | None = None
         self._background_tasks: set[AsyncTask[Any]] = set()

--- a/control_plane/tasks/client/resource_client.py
+++ b/control_plane/tasks/client/resource_client.py
@@ -101,7 +101,14 @@ def should_ignore_resource(region: str, resource_type: str, resource_name: str) 
 
 
 class ResourceClient(AbstractAsyncContextManager["ResourceClient"]):
-    def __init__(self, log: Logger, cred: DefaultAzureCredential, tag_filters: list[str], subscription_id: str) -> None:
+    def __init__(
+        self,
+        log: Logger,
+        cred: DefaultAzureCredential,
+        tag_filters: list[str],
+        subscription_id: str,
+        base_url: str = "https://management.azure.com",
+    ) -> None:
         super().__init__()
         self.log = log
         self.credential = cred
@@ -110,18 +117,18 @@ class ResourceClient(AbstractAsyncContextManager["ResourceClient"]):
         """Predicate which takes a resource's tags as input and evaluates them against the
         user-configured `tag_filters` to determine whether the resource's logs should be forwarded"""
 
-        self.resources_client = ResourceManagementClient(cred, subscription_id)
-        redis_client = RedisEnterpriseManagementClient(cred, subscription_id)
-        cdn_client = CdnManagementClient(cred, subscription_id)
-        healthcareapis_client = HealthcareApisManagementClient(cred, subscription_id)
-        media_client = AzureMediaServices(cred, subscription_id)
-        network_client = NetworkManagementClient(cred, subscription_id)
-        netapp_client = NetAppManagementClient(cred, subscription_id)
-        notificationhubs_client = NotificationHubsManagementClient(cred, subscription_id)
-        powerbi_client = PowerBIEmbeddedManagementClient(cred, subscription_id)
-        sql_client = SqlManagementClient(cred, subscription_id)
-        synapse_client = SynapseManagementClient(cred, subscription_id)
-        web_client = WebSiteManagementClient(cred, subscription_id)
+        self.resources_client = ResourceManagementClient(cred, subscription_id, base_url=base_url)
+        redis_client = RedisEnterpriseManagementClient(cred, subscription_id, base_url=base_url)
+        cdn_client = CdnManagementClient(cred, subscription_id, base_url=base_url)
+        healthcareapis_client = HealthcareApisManagementClient(cred, subscription_id, base_url=base_url)
+        media_client = AzureMediaServices(cred, subscription_id, base_url=base_url)
+        network_client = NetworkManagementClient(cred, subscription_id, base_url=base_url)
+        netapp_client = NetAppManagementClient(cred, subscription_id, base_url=base_url)
+        notificationhubs_client = NotificationHubsManagementClient(cred, subscription_id, base_url=base_url)
+        powerbi_client = PowerBIEmbeddedManagementClient(cred, subscription_id, base_url=base_url)
+        sql_client = SqlManagementClient(cred, subscription_id, base_url=base_url)
+        synapse_client = SynapseManagementClient(cred, subscription_id, base_url=base_url)
+        web_client = WebSiteManagementClient(cred, subscription_id, base_url=base_url)
 
         # map of resource type to client and sub resource fetching function
         self._get_sub_resources_map: Final[

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -59,7 +59,9 @@ class DeployerTask(Task):
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)
         self.region = get_config_option(CONTROL_PLANE_REGION_SETTING)
         self.rest_client = ClientSession()
-        self.web_client = WebSiteManagementClient(self.credential, self.subscription_id)
+        self.web_client = WebSiteManagementClient(
+            self.credential, self.subscription_id, base_url=get_azure_mgmt_url(self.region)
+        )
 
         storage_account_url = environ.get(STORAGE_ACCOUNT_URL_SETTING, PUBLIC_STORAGE_ACCOUNT_URL)
         # If authenticating with the public storage account, we use anonymous access since the blobs are public.

--- a/control_plane/tasks/diagnostic_settings_task.py
+++ b/control_plane/tasks/diagnostic_settings_task.py
@@ -34,10 +34,11 @@ from cache.diagnostic_settings_cache import (
     remove_cached_resource,
     update_cached_event,
 )
-from cache.env import CONTROL_PLANE_ID_SETTING, RESOURCE_GROUP_SETTING, get_config_option
+from cache.env import CONTROL_PLANE_ID_SETTING, CONTROL_PLANE_REGION_SETTING, RESOURCE_GROUP_SETTING, get_config_option
 from cache.resources_cache import INCLUDE_KEY, RESOURCE_CACHE_BLOB, deserialize_resource_cache
 from tasks.client.datadog_api_client import StatusCode
 from tasks.common import (
+    get_azure_mgmt_url,
     get_event_hub_name,
     get_event_hub_namespace,
     get_resource_group_id,
@@ -100,6 +101,7 @@ class DiagnosticSettingsTask(Task):
         super().__init__(is_initial_run=is_initial_run, execution_id=execution_id)
 
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)
+        self.base_url = get_azure_mgmt_url(get_config_option(CONTROL_PLANE_REGION_SETTING))
         self.diagnostic_settings_name = (
             DIAGNOSTIC_SETTING_PREFIX + get_config_option(CONTROL_PLANE_ID_SETTING)
         ).lower()
@@ -132,7 +134,7 @@ class DiagnosticSettingsTask(Task):
     async def process_subscription(self, sub_id: str) -> None:
         self.log.info("Processing subscription %s", sub_id)
         # we assume if a resource isn't in the assignment cache then is has been deleted
-        async with MonitorManagementClient(self.credential, sub_id) as client:
+        async with MonitorManagementClient(self.credential, sub_id, base_url=self.base_url) as client:
             # TODO: do we want to do anything with management group diagnostic settings?
             # client.management_group_diagnostic_settings.list("management_group_id")
             resources = [

--- a/control_plane/tasks/resources_task.py
+++ b/control_plane/tasks/resources_task.py
@@ -14,7 +14,12 @@ from azure.mgmt.resource.subscriptions.v2021_01_01.aio import SubscriptionClient
 
 # project
 from cache.common import write_cache
-from cache.env import CONTROL_PLANE_REGION_SETTING, MONITORED_SUBSCRIPTIONS_SETTING, RESOURCE_TAG_FILTERS_SETTING
+from cache.env import (
+    CONTROL_PLANE_REGION_SETTING,
+    MONITORED_SUBSCRIPTIONS_SETTING,
+    RESOURCE_TAG_FILTERS_SETTING,
+    get_config_option,
+)
 from cache.resources_cache import (
     RESOURCE_CACHE_BLOB,
     ResourceCache,
@@ -36,7 +41,7 @@ class ResourcesTask(Task):
 
     def __init__(self, resource_cache_state: str, execution_id: str = "", is_initial_run: bool = False) -> None:
         super().__init__(is_initial_run=is_initial_run, execution_id=execution_id)
-        self.base_url = get_azure_mgmt_url(getenv(CONTROL_PLANE_REGION_SETTING, ""))
+        self.base_url = get_azure_mgmt_url(get_config_option(CONTROL_PLANE_REGION_SETTING))
         self.monitored_subscriptions = deserialize_monitored_subscriptions(
             getenv(MONITORED_SUBSCRIPTIONS_SETTING) or ""
         )

--- a/control_plane/tasks/resources_task.py
+++ b/control_plane/tasks/resources_task.py
@@ -87,7 +87,9 @@ class ResourcesTask(Task):
 
     async def process_subscription(self, subscription_id: str) -> None:
         self.log.debug("Processing the following subscription: %s", subscription_id)
-        async with ResourceClient(self.log, self.credential, self.tag_filter_list, subscription_id, self.base_url) as client:
+        async with ResourceClient(
+            self.log, self.credential, self.tag_filter_list, subscription_id, self.base_url
+        ) as client:
             try:
                 self.resource_cache[subscription_id] = await client.get_resources_per_region()
             except HttpResponseError as e:

--- a/control_plane/tasks/resources_task.py
+++ b/control_plane/tasks/resources_task.py
@@ -14,7 +14,7 @@ from azure.mgmt.resource.subscriptions.v2021_01_01.aio import SubscriptionClient
 
 # project
 from cache.common import write_cache
-from cache.env import MONITORED_SUBSCRIPTIONS_SETTING, RESOURCE_TAG_FILTERS_SETTING
+from cache.env import CONTROL_PLANE_REGION_SETTING, MONITORED_SUBSCRIPTIONS_SETTING, RESOURCE_TAG_FILTERS_SETTING
 from cache.resources_cache import (
     RESOURCE_CACHE_BLOB,
     ResourceCache,
@@ -25,6 +25,7 @@ from cache.resources_cache import (
 )
 from tasks.client.datadog_api_client import StatusCode
 from tasks.client.resource_client import ResourceClient
+from tasks.common import get_azure_mgmt_url
 from tasks.task import Task, task_main
 
 RESOURCES_TASK_NAME = "resources_task"
@@ -35,6 +36,7 @@ class ResourcesTask(Task):
 
     def __init__(self, resource_cache_state: str, execution_id: str = "", is_initial_run: bool = False) -> None:
         super().__init__(is_initial_run=is_initial_run, execution_id=execution_id)
+        self.base_url = get_azure_mgmt_url(getenv(CONTROL_PLANE_REGION_SETTING, ""))
         self.monitored_subscriptions = deserialize_monitored_subscriptions(
             getenv(MONITORED_SUBSCRIPTIONS_SETTING) or ""
         )
@@ -57,7 +59,7 @@ class ResourcesTask(Task):
             await self.write_caches(is_schema_upgrade=True)
             self.schema_upgrade = False
 
-        async with SubscriptionClient(self.credential) as subscription_client:
+        async with SubscriptionClient(self.credential, base_url=self.base_url) as subscription_client:
             try:
                 subscriptions = [
                     cast(str, sub.subscription_id).lower() async for sub in subscription_client.subscriptions.list()
@@ -85,7 +87,7 @@ class ResourcesTask(Task):
 
     async def process_subscription(self, subscription_id: str) -> None:
         self.log.debug("Processing the following subscription: %s", subscription_id)
-        async with ResourceClient(self.log, self.credential, self.tag_filter_list, subscription_id) as client:
+        async with ResourceClient(self.log, self.credential, self.tag_filter_list, subscription_id, self.base_url) as client:
             try:
                 self.resource_cache[subscription_id] = await client.get_resources_per_region()
             except HttpResponseError as e:

--- a/control_plane/tasks/tests/test_resources_task.py
+++ b/control_plane/tasks/tests/test_resources_task.py
@@ -14,6 +14,7 @@ from azure.core.exceptions import HttpResponseError
 # project
 from cache.env import (
     CONTROL_PLANE_ID_SETTING,
+    CONTROL_PLANE_REGION_SETTING,
 )
 from cache.resources_cache import (
     RESOURCE_CACHE_BLOB,
@@ -48,7 +49,8 @@ class TestResourcesTask(TaskTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.sub_client = AsyncMockClient()
-        self.patch("SubscriptionClient").return_value = self.sub_client
+        self.subscription_client_mock = self.patch("SubscriptionClient")
+        self.subscription_client_mock.return_value = self.sub_client
         self.datadog_client = AsyncMockClient()
         self.patch_path("tasks.task.DatadogClient").return_value = self.datadog_client
         self.resource_client = self.patch("ResourceClient")
@@ -57,9 +59,11 @@ class TestResourcesTask(TaskTestCase):
 
         self.resource_mock_client = AsyncMockClient()
         self.resource_mock_client.log = self.log
+        self.last_resource_client_base_url: str | None = None
 
-        def create_resource_client(_log: Any, _cred: Any, _tags: Any, sub_id: str, _base_url: str = ""):
+        def create_resource_client(_log: Any, _cred: Any, _tags: Any, sub_id: str, base_url: str = ""):
             assert sub_id in self.resource_client_mapping, "subscription not mocked properly"
+            self.last_resource_client_base_url = base_url
             self.resource_mock_client.get_resources_per_region.return_value = self.resource_client_mapping[sub_id]
             return self.resource_mock_client
 
@@ -107,6 +111,22 @@ class TestResourcesTask(TaskTestCase):
                 sub_id2: {SUPPORTED_REGION_2: {"res3": included_metadata}},
             },
         )
+        self.subscription_client_mock.assert_called_once_with(self.credential, base_url="https://management.azure.com")
+        self.assertEqual(self.last_resource_client_base_url, "https://management.azure.com")
+
+    async def test_gov_cloud_base_url(self):
+        self.env[CONTROL_PLANE_REGION_SETTING] = "usgovarizona"
+        self.sub_client.subscriptions.list = Mock(return_value=async_generator(sub1))
+        self.resource_client_mapping = {
+            sub_id1: {SUPPORTED_REGION_1: {"res1": included_metadata}},
+        }
+
+        await self.run_resources_task({})
+
+        self.subscription_client_mock.assert_called_once_with(
+            self.credential, base_url="https://management.usgovcloudapi.net"
+        )
+        self.assertEqual(self.last_resource_client_base_url, "https://management.usgovcloudapi.net")
 
     async def test_cache_upgrade_schema(self):
         self.sub_client.subscriptions.list = Mock(return_value=async_generator(sub1, sub2))

--- a/control_plane/tasks/tests/test_resources_task.py
+++ b/control_plane/tasks/tests/test_resources_task.py
@@ -58,7 +58,7 @@ class TestResourcesTask(TaskTestCase):
         self.resource_mock_client = AsyncMockClient()
         self.resource_mock_client.log = self.log
 
-        def create_resource_client(_log: Any, _cred: Any, _tags: Any, sub_id: str):
+        def create_resource_client(_log: Any, _cred: Any, _tags: Any, sub_id: str, _base_url: str = ""):
             assert sub_id in self.resource_client_mapping, "subscription not mocked properly"
             self.resource_mock_client.get_resources_per_region.return_value = self.resource_client_mapping[sub_id]
             return self.resource_mock_client


### PR DESCRIPTION
## Context
A customer in Azure Government reported that the deployer task constantly fails and downstream resources (ddlogstorage accounts, resources.json, diagnostic settings) are never created. The most recent error shared shows that the subscriptions query does not return any results. A possible root cause is that SDK management clients default to `https://management.azure.com`, where government subscriptions don't exist. Recent PRs (#478) fixed `initial_run.py` and the deployer task's REST calls, but several other SDK client instantiations were missed.

## Change summary
- Adds `base_url` to all Azure SDK management clients that were still defaulting to `management.azure.com`.
- Affects `SubscriptionClient`, `ResourceManagementClient` (+ 11 resource-type clients), `ContainerAppsAPIClient`, `StorageManagementClient`, `MonitorManagementClient`, and `WebSiteManagementClient` in the deployer task

## Test plan
- Made a personal LFO deployment, [ran successfully](https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id/%2Fproviders%2FMicrosoft.Management%2FmanagementGroups%2FAzure-Integrations-Mg%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2Flfobenblaustein) and we received [logs](https://app.datadoghq.com/logs?query=source%3Aazure%20%40control_plane_id%3A3fd0a8226c47&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1775854149387&to_ts=1775858395816&live=false).