### PR TITLE
Fix managed env deletion fallback

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -477,6 +477,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
 
         @retry(stop=stop_after_attempt(max_attempts), retry=is_exception_retryable)
         async def _delete_forwarder_env() -> None:
+            container_app_region = self.get_container_app_region(region)
             self.log.info(
                 "Attempting to delete log forwarder env for region %s and control plane %s",
                 region,
@@ -488,7 +489,7 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
                 ResourceNotFoundError,
                 self.container_apps_client.managed_environments.begin_delete(
                     self.resource_group,
-                    get_managed_env_name(region, self.control_plane_id),
+                    get_managed_env_name(container_app_region, self.control_plane_id),
                 ),
             )
             if poller:

--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -449,6 +449,20 @@ class TestLogForwarderClient(AsyncTestCase):
             RESOURCE_GROUP_NAME, env_name
         )
 
+    async def test_delete_log_forwarder_env_unsupported_region_defaults_to_control_plane_region(self):
+        # GIVEN
+        env_name = get_managed_env_name(EAST_US, CONTROL_PLANE_ID)
+
+        # WHEN
+        async with self.client as client:
+            success = await client.delete_log_forwarder_env(NEW_ZEALAND_NORTH)
+
+        # THEN
+        self.assertTrue(success)
+        self.client.container_apps_client.managed_environments.begin_delete.assert_awaited_once_with(
+            RESOURCE_GROUP_NAME, env_name
+        )
+
     async def test_delete_log_forwarder_env_ignore_resource_not_found(self):
         # GIVEN
         env_name = get_managed_env_name(EAST_US, CONTROL_PLANE_ID)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3b51ceae-16b4-4822-aa55-6f3dd261959a","source":"chat","resourceId":"d23e3550-262b-4745-b018-38ed43c530ed","workflowId":"19aa39cf-96c0-4dc1-a6fd-e370ddc48a4f","codeChangeId":"19aa39cf-96c0-4dc1-a6fd-e370ddc48a4f","sourceType":"chat"} -->
## Description

### Motivation
- Managed environments for unsupported Azure regions are created and looked up using the control plane's fallback container-app region.
- `delete_log_forwarder_env` used the original unsupported region instead, so cleanup targeted the wrong managed-environment name and could leave the real environment behind.

### Changes
- Normalize the region in `delete_log_forwarder_env` with `get_container_app_region(...)` before building the managed-environment name.
- Add a regression test that covers deleting a managed environment for an unsupported region such as `newzealandnorth`.

Jira issue:

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
- `/workspace/repo/.venv/bin/python -m pytest tasks/client/tests/test_log_forwarder_client.py -q`
- `/workspace/repo/.venv/bin/python -m ruff check tasks/client/log_forwarder_client.py tasks/client/tests/test_log_forwarder_client.py`
- `/workspace/repo/.venv/bin/python -m ruff format --check tasks/client/log_forwarder_client.py tasks/client/tests/test_log_forwarder_client.py`

## Rollout
- Backwards compatible: this aligns managed-environment deletion with the fallback-region behavior already used by the create and get paths.

 - [x] I have verified that this change is backwards compatible.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d23e3550-262b-4745-b018-38ed43c530ed)

Comment @datadog to request changes