### PR TITLE
Forward is_initial_run in DeployerTask init

### DIFF
--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -60,7 +60,7 @@ class DeployerTask(Task):
     NAME = DEPLOYER_TASK_NAME
 
     def __init__(self, is_initial_run: bool = False) -> None:
-        super().__init__()
+        super().__init__(is_initial_run=is_initial_run)
         self.subscription_id = get_config_option(SUBSCRIPTION_ID_SETTING)
         self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)
         self.region = get_config_option(CONTROL_PLANE_REGION_SETTING)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"eec01015-55ce-4d94-ba49-9a5e58181e19","source":"chat","resourceId":"aa36484b-e1fb-4b9a-9485-9a81174ca4ba","workflowId":"3a4a3a66-961c-4104-a8e0-1f290c89351d","codeChangeId":"3a4a3a66-961c-4104-a8e0-1f290c89351d","sourceType":"chat"} -->
## Description

`DeployerTask.__init__` accepts `is_initial_run` but never forwards it to `super().__init__()`, so `Task._is_initial_run` is always `False` for deployer runs. Both `ResourcesTask` and `DiagnosticSettingsTask` correctly pass this parameter. This fix aligns `DeployerTask` with the other task subclasses so that `is_initial_run` is properly propagated to the base `Task` class, which uses it to gate `submit_status_update()` calls.

Jira issue:

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing

- All 11 existing `test_deployer_task.py` tests pass.

## Rollout

This is a one-line fix that only corrects parameter forwarding in the constructor. It has no effect on current behavior since `DeployerTask.run()` does not yet call `submit_status_update`, but it prevents a silent no-op if status updates are added in the future.

 - [x] I have verified that this change is backwards compatible.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/aa36484b-e1fb-4b9a-9485-9a81174ca4ba)

Comment @datadog to request changes