### PR TITLE
Protect flow log cursors on cancel

### DIFF
--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -73,6 +73,7 @@ func getLogs(ctx context.Context, storageClient *storage.Client, cursors *cursor
 }
 
 func parseLogs(ctx context.Context, reader io.ReadCloser, blob storage.Blob, piiScrubber logs.Scrubber, logsChannel chan<- *logs.Log) (int64, int64, error) {
+	var processedRawBytes int64
 	var processedLogs int64
 
 	var currLog *logs.Log
@@ -88,15 +89,19 @@ func parseLogs(ctx context.Context, reader io.ReadCloser, blob storage.Blob, pii
 			break
 		}
 		currLog = parsedLog.ParsedLog
+		cursorBoundary := currLog.RawLength() > 0
 
 		select {
 		case logsChannel <- currLog:
+			if cursorBoundary {
+				processedRawBytes = int64(*totalBytes)
+			}
 			processedLogs += 1
 		case <-ctx.Done():
-			return int64(*totalBytes), processedLogs, err
+			return processedRawBytes, processedLogs, err
 		}
 	}
-	return int64(*totalBytes), processedLogs, err
+	return processedRawBytes, processedLogs, err
 }
 
 func processLogs(ctx context.Context, logsClient *logs.Client, now customtime.Now, logger *log.Entry, logsCh <-chan *logs.Log, resourceIdCh chan<- string, resourceBytesCh chan<- resourceBytes) (err error) {

--- a/forwarder/cmd/forwarder/forwarder_test.go
+++ b/forwarder/cmd/forwarder/forwarder_test.go
@@ -997,6 +997,48 @@ func TestParseLogs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, got, 3)
 	})
+
+	t.Run("does not advance the cursor past an incomplete flow event line on cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		reader := io.NopCloser(strings.NewReader(vnetFlowLogData))
+		logsChannel := make(chan *logs.Log)
+		type parseResult struct {
+			processedRawBytes int64
+			processedLogs     int64
+			err               error
+		}
+		resultChannel := make(chan parseResult, 1)
+
+		go func() {
+			processedRawBytes, processedLogs, err := parseLogs(
+				ctx,
+				reader,
+				newBlob(resourceId, "insights-logs-flowlogflowevent"),
+				newMockPiiScrubber(ctrl),
+				logsChannel,
+			)
+			resultChannel <- parseResult{
+				processedRawBytes: processedRawBytes,
+				processedLogs:     processedLogs,
+				err:               err,
+			}
+		}()
+
+		firstLog := <-logsChannel
+		require.NotNil(t, firstLog)
+
+		cancel()
+
+		result := <-resultChannel
+		assert.NoError(t, result.err)
+		assert.Equal(t, int64(1), result.processedLogs)
+		assert.Zero(t, result.processedRawBytes)
+	})
 }
 
 var (

--- a/forwarder/internal/logs/parse.go
+++ b/forwarder/internal/logs/parse.go
@@ -45,18 +45,17 @@ func unmarshalFlowEventRecords[T any](bytes []byte) (*flowEventRecords[T], error
 }
 
 func processFlowEventRecords[T flowEventRecord](flowEventRecords *flowEventRecords[T], blob storage.Blob, originalSize int, scrubbedSize int, piiScrubber Scrubber, yield func(ParsedLogResponse) bool) bool {
-	response := ParsedLogResponse{}
 	for idx, flowEventLog := range flowEventRecords.Records {
 		currLog, err := flowEventLog.ToLog(blob)
-		response.ParsedLog = currLog
+		response := ParsedLogResponse{ParsedLog: currLog}
 		if err != nil {
 			response.Err = err
 			yield(response)
 			return false
 		}
 		if idx == len(flowEventRecords.Records)-1 {
-			response.ParsedLog.RawByteSize = int64(originalSize)
-			response.ParsedLog.ScrubbedByteSize = int64(scrubbedSize)
+			currLog.RawByteSize = int64(originalSize)
+			currLog.ScrubbedByteSize = int64(scrubbedSize)
 		}
 
 		if !yield(response) {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1165e745-365d-47b9-866f-ad15960cbd90","source":"chat","resourceId":"349e9e69-8a80-4452-8788-8b46a736ef60","workflowId":"3724d3cd-ce91-40a3-af26-38b81760860b","codeChangeId":"3724d3cd-ce91-40a3-af26-38b81760860b","sourceType":"chat"} -->
## Description
Fix the forwarder so a cancelled run does not move blob cursors past flow-event records that were parsed but never handed off downstream.

This change affects:
 - [ ] Control Plane Tasks
 - [x] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

Jira issue:

### Motivation
The forwarder was using scanner-consumed byte counts as the persisted cursor position. If cancellation happened after a flow-event line had been scanned but before its final record was sent, the next run could resume after unsent data and permanently skip logs.

### Changes
- Update `forwarder/cmd/forwarder/forwarder.go` so `parseLogs` only advances the cursor to the last safely enqueued log boundary instead of blindly using all bytes the scanner consumed.
- Keep flow-event parser boundary metadata consistent in `forwarder/internal/logs/parse.go` by assigning the raw/scrubbed byte markers directly to the final emitted record for a scanned line.
- Add a regression test in `forwarder/cmd/forwarder/forwarder_test.go` that cancels mid-flow-event parsing and verifies the cursor does not advance past unsent records.

## Testing
- `cd /workspace/repo/forwarder && go test ./cmd/forwarder -run TestParseLogs`
- `cd /workspace/repo/forwarder && go test ./internal/logs -run TestParseVnetFlowLogs`
- `cd /workspace/repo/forwarder && go build -o /dev/null ./cmd/forwarder && go vet ./cmd/forwarder ./internal/logs`
- Ran repository formatter tooling (`Format`) after the change; no further file updates were needed.

## Rollout
This is backwards compatible because it only makes cursor persistence more conservative during interrupted flow-event processing, preferring replay over data loss.

 - [x] I have verified that this change is backwards compatible.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/349e9e69-8a80-4452-8788-8b46a736ef60)

Comment @datadog to request changes