### PR TITLE
Fix re-enabling disabled log categories

### DIFF
--- a/control_plane/tasks/diagnostic_settings_task.py
+++ b/control_plane/tasks/diagnostic_settings_task.py
@@ -285,7 +285,7 @@ class DiagnosticSettingsTask(Task):
             resource_id,
             assigned_config,
             # keep the same categories selected (or add all if new), just fix the storage account
-            categories=current_setting and [cast(str, log.category) for log in (current_setting.logs or [])],
+            categories=current_setting and [cast(str, log.category) for log in (current_setting.logs or []) if log.enabled],
         )
 
         if current_setting is None and add_setting_success:
@@ -304,11 +304,12 @@ class DiagnosticSettingsTask(Task):
         Returns True if the diagnostic setting was successfully created or updated, False otherwise
         """
         try:
-            categories = categories or [
-                cast(str, category.name)
-                async for category in client.diagnostic_settings_category.list(resource_id)
-                if category.category_type == CategoryType.LOGS
-            ]
+            if categories is None:
+                categories = [
+                    cast(str, category.name)
+                    async for category in client.diagnostic_settings_category.list(resource_id)
+                    if category.category_type == CategoryType.LOGS
+                ]
             if not categories:
                 self.log.debug("No log categories found for resource %s", resource_id)
                 return False

--- a/control_plane/tasks/tests/repro_bug.py
+++ b/control_plane/tasks/tests/repro_bug.py
@@ -1,0 +1,88 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
+
+from json import dumps
+from unittest.mock import Mock, patch
+from azure.mgmt.monitor.models import CategoryType
+from tasks.diagnostic_settings_task import DIAGNOSTIC_SETTING_PREFIX, DiagnosticSettingsTask
+from tasks.tests.common import TaskTestCase, async_generator, mock, AzureModelMatcher
+from cache.common import STORAGE_ACCOUNT_TYPE
+
+sub_id1 = "sub1"
+region1 = "region1"
+config_id1 = "bc666ef914ec"
+control_plane_id = "e90ecb54476d"
+DIAGNOSTIC_SETTING_NAME = DIAGNOSTIC_SETTING_PREFIX + control_plane_id
+resource_id1 = "/subscriptions/1/resourcegroups/rg1/providers/microsoft.compute/virtualmachines/vm1"
+
+class TestDiagnosticSettingsBug(TaskTestCase):
+    TASK_NAME = "diagnostic_settings_task"
+    def setUp(self) -> None:
+        super().setUp()
+        self.patch_path("tasks.task.DatadogClient")
+        self.client = self.patch("MonitorManagementClient").return_value.__aenter__.return_value
+        self.client.diagnostic_settings.list = Mock()
+        self.list_settings = self.client.diagnostic_settings.list
+        self.client.diagnostic_settings_category.list = Mock()
+        self.list_categories = self.client.diagnostic_settings_category.list
+        self.create_or_update = self.client.diagnostic_settings.create_or_update
+        
+        with patch.dict("os.environ", {"RESOURCE_GROUP": "lfo", "CONTROL_PLANE_ID": control_plane_id}):
+            pass
+
+    async def test_bug_reenables_all_categories_when_empty(self):
+        # GIVEN: An existing diagnostic setting with NO enabled logs
+        self.list_settings.return_value = async_generator(
+            mock(
+                name=DIAGNOSTIC_SETTING_NAME,
+                storage_account_id="wrong_id",
+                logs=[] # No logs enabled
+            )
+        )
+        # AND: The resource has some categories available
+        self.list_categories.return_value = async_generator(
+            mock(name="category1", category_type=CategoryType.LOGS),
+            mock(name="category2", category_type=CategoryType.LOGS)
+        )
+
+        # WHEN: Running the task
+        async with DiagnosticSettingsTask(
+            dumps({}),
+            dumps({sub_id1: {region1: {"configurations": {config_id1: STORAGE_ACCOUNT_TYPE}, "resources": {resource_id1: config_id1}}}}),
+            dumps({})
+        ) as task:
+            await task.run()
+
+        # THEN: It should NOT have re-enabled all categories!
+        # It should have returned False and not called create_or_update because categories is []
+        self.create_or_update.assert_not_awaited()
+
+    async def test_bug_reenables_disabled_categories(self):
+        # GIVEN: An existing diagnostic setting with one enabled and one disabled category
+        self.list_settings.return_value = async_generator(
+            mock(
+                name=DIAGNOSTIC_SETTING_NAME,
+                storage_account_id="wrong_id",
+                logs=[
+                    mock(category="enabled_cat", enabled=True),
+                    mock(category="disabled_cat", enabled=False)
+                ]
+            )
+        )
+
+        # WHEN: Running the task
+        async with DiagnosticSettingsTask(
+            dumps({}),
+            dumps({sub_id1: {region1: {"configurations": {config_id1: STORAGE_ACCOUNT_TYPE}, "resources": {resource_id1: config_id1}}}}),
+            dumps({})
+        ) as task:
+            await task.run()
+
+        # THEN: It should ONLY have kept the enabled one
+        self.create_or_update.assert_awaited_once()
+        args = self.create_or_update.call_args[0]
+        sent_settings = args[2]
+        
+        sent_categories = [l.category for l in sent_settings.logs]
+        self.assertIn("enabled_cat", sent_categories)
+        self.assertNotIn("disabled_cat", sent_categories, "Should NOT have re-enabled disabled category")


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1dd6aabc-f147-4cc9-a654-d6ca6c18ddef","source":"chat","resourceId":"b468a0cf-2ffd-4ac7-96c6-506a68bd6ea7","workflowId":"413996ec-d81b-4f5d-97e3-97ad90888faa","codeChangeId":"413996ec-d81b-4f5d-97e3-97ad90888faa","sourceType":"chat"} -->
## Description

Fixes a bug in DiagnosticSettingsTask where disabled log categories were being re-enabled when updating diagnostic settings.

**What behavior has been changed:**
- When updating an existing diagnostic setting with a new storage account, the task now correctly preserves only enabled log categories instead of re-enabling all previously disabled ones
- Changed logic to filter logs by `enabled` status when carrying forward existing categories
- Fixed the `categories` parameter handling to distinguish between `None` (use all available) and empty list (use none)

**Which services/components are affected:**
- Control Plane Tasks: DiagnosticSettingsTask

**Why is the change important:**
The bug caused diagnostic settings to re-enable log categories that were intentionally disabled, potentially increasing costs and sending unwanted logs. The fix ensures user intent is preserved when updating storage account configurations.

Jira issue:

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing

Unit tests added in `control_plane/tasks/tests/repro_bug.py` covering:
- Scenario where diagnostic setting has no enabled logs (should not re-enable all)
- Scenario where diagnostic setting has mixed enabled/disabled logs (should preserve only enabled)

## Rollout

 - [x] I have verified that this change is backwards compatible.

The change is backwards compatible as it only fixes incorrect behavior and properly preserves existing diagnostic settings configuration.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b468a0cf-2ffd-4ac7-96c6-506a68bd6ea7)

Comment @datadog to request changes