### PR TITLE
[forwarder] Update dd-evp-origin header

### DIFF
--- a/forwarder/cmd/forwarder/forwarder.go
+++ b/forwarder/cmd/forwarder/forwarder.go
@@ -36,6 +36,8 @@ import (
 
 const (
 	ForwarderMaxRuntime = 45 * time.Second
+	EvpOriginHeader     = "dd-evp-origin"
+	LfoValue            = "lfo"
 )
 
 // resourceBytes is a struct to hold the resource id and the number of bytes processed for that resource.
@@ -314,7 +316,7 @@ func processDeadLetterQueue(ctx context.Context, now customtime.Now, logger *log
 func run(ctx context.Context, logParent *log.Logger, goroutineCount int, datadogConfig *datadog.Configuration, azBlobClient storage.AzureBlobClient, piiScrubber logs.Scrubber, now customtime.Now, versionTag string) error {
 	start := time.Now()
 
-	datadogConfig.AddDefaultHeader("dd_evp_origin", "lfo")
+	datadogConfig.AddDefaultHeader(EvpOriginHeader, LfoValue)
 	datadogConfig.RetryConfiguration.HTTPRetryTimeout = 90 * time.Second
 	datadogClient := datadog.NewAPIClient(datadogConfig)
 	datadogLogsClient := datadogV2.NewLogsApi(datadogClient)

--- a/forwarder/cmd/forwarder/forwarder_test.go
+++ b/forwarder/cmd/forwarder/forwarder_test.go
@@ -364,7 +364,7 @@ func TestRun(t *testing.T) {
 		}
 
 		assert.Equal(t, "gzip", latestHeaders.Get("Content-Encoding"))
-		assert.Equal(t, "lfo", latestHeaders.Get("dd_evp_origin"))
+		assert.Equal(t, LfoValue, latestHeaders.Get(EvpOriginHeader))
 	})
 
 	t.Run("continues processing on errors", func(t *testing.T) {


### PR DESCRIPTION
## Description
We were setting an incorrect header for `dd-evp-origin` on LFO requests. It needs to use hyphens instead of underscores. This needs to be corrected to get an idea of how many GB are being ingested per org for the [azure billing update](https://azure.microsoft.com/en-us/pricing/details/monitor/). MSFT will be charging $0.25 per GB of exported logs. 

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-4691

This change affects:
 - [ ] Control Plane Tasks
 - [x] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
Unit tests passing


