### PR TITLE
Remove virtual machines constant from tasks

### DIFF
--- a/control_plane/tasks/constants.py
+++ b/control_plane/tasks/constants.py
@@ -34,7 +34,6 @@ UNNESTED_VALID_RESOURCE_TYPES: Final[frozenset[str]] = frozenset(
         "microsoft.cognitiveservices/accounts",
         "microsoft.communication/communicationservices",
         "microsoft.community/communitytrainings",
-        "microsoft.compute/virtualmachines",
         "microsoft.confidentialledger/managedccf",
         "microsoft.confidentialledger/managedccfs",
         "microsoft.connectedcache/cachenodes",


### PR DESCRIPTION
VMs doesn't seem to support diagnosticSettingsCategories API.                                                                                                              

[Diagnostic Settings in Azure Monitor - Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings?tabs=portal)                                                                                                                                                               

[Diagnostic Settings Category - List REST API](https://learn.microsoft.com/en-us/rest/api/monitor/diagnostic-settings-category/list?view=rest-monitor-2021-05-01-preview&tabs=HTTP&tryIt=true&source=docs#code-try-0)

There are also no Log table for VM.
[Supported log categories - Microsoft.Compute/virtualMachines - Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-logs/microsoft-compute-virtualmachines-logs)