### PR TITLE
[AZINTS-4759] Create deployer to update container app control plane

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,22 @@ publish-tasks:
     - control_plane/scripts/publish.py https://ddazurelfo.blob.core.windows.net
   dependencies:
     - build-tasks
+publish-task-images:
+  image: $CI_IMAGE
+  stage: publish
+  tags: [ "arch:amd64" ]
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: manual
+  variables:
+    KUBERNETES_POD_ANNOTATIONS_azure: cloud-iam.emissary.datadoghq.com/azure=88d13348-0530-418a-89c0-9caa32d59037
+  needs:
+    - resources-task-build-tagged
+    - scaling-task-build-tagged
+    - diagnostic-settings-task-build-tagged
+  script:
+    - control_plane/scripts/publish_images.py https://ddazurelfo.blob.core.windows.net
+      $INTERNAL_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 uninstall-script-publish:
   image: $CI_IMAGE
   stage: publish
@@ -392,6 +408,26 @@ publish-tasks-qa:
     - control_plane/scripts/publish.py https://lfoqa.blob.core.windows.net
   dependencies:
     - build-tasks
+publish-task-images-qa:
+  image: $CI_IMAGE
+  stage: publish-qa
+  tags: [ "arch:amd64" ]
+  only:
+    refs:
+      - main
+  script:
+    - export AZURE_TENANT_ID=$(vault kv get -field=azureTenantId
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - export AZURE_CLIENT_ID=$(vault kv get -field=azureClientId
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - export AZURE_CLIENT_SECRET=$(vault kv get -field=azureSecret
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - control_plane/scripts/publish_images.py https://lfoqa.blob.core.windows.net
+      $INTERNAL_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+  needs:
+    - resources-task-build-tagged
+    - scaling-task-build-tagged
+    - diagnostic-settings-task-build-tagged
 deploy-qa-env:
   image: $CI_IMAGE
   stage: publish-qa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,89 +14,101 @@ stages:
   - publish-qa
   - publish
 # ------------- CI IMAGE -------------
+# Rebuilds the CI image used by all other jobs; run manually when ci/build-image/Dockerfile changes
 ci-build-image:
   image: $DOCKER_IMAGE
   stage: ci-image
   rules:
     - when: manual
       allow_failure: true
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform linux/amd64 --tag "$CI_IMAGE" -f
       "ci/build-image/Dockerfile" . --push
 # ------------- CONTROL PLANE -------------
+# Runs the control plane Python test suite and uploads a coverage report artifact
 control-plane-tests:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - ci/scripts/control_plane/test.sh
   artifacts:
     paths:
       - ci/control_plane_coverage.md
+# Verifies that all control plane dependencies are pinned and consistent
 control-plane-test-dependencies:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - ci/scripts/control_plane/test-dependencies.sh
+# Checks that control plane Python code is formatted with ruff
 control-plane-formatting:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - ci/scripts/control_plane/format.sh
+# Lints control plane Python code with ruff
 control-plane-lint:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - ci/scripts/control_plane/lint.sh
+# Type-checks control plane Python code with pyright
 control-plane-type-check:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - ci/scripts/control_plane/type-check.sh
+# Verifies the deployer (Function App) Docker image builds successfully
 deployer-test-build:
   image: $DOCKER_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 -f
       "ci/deployer-task/Dockerfile" ./control_plane
+# Verifies the deployer-caj (Container App Job) Docker image builds successfully
 deployer-caj-test-build:
   image: $DOCKER_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 -f
       "ci/deployer-caj-task/Dockerfile" ./control_plane
+# Verifies the resources-task Docker image (for CAJ control plane) builds successfully
 resources-task-test-build:
   image: $DOCKER_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 -f
       "ci/resources-task/Dockerfile" ./control_plane
+# Verifies the diagnostic-settings-task Docker image (for CAJ control plane) builds successfully
 diagnostic-settings-task-test-build:
   image: $DOCKER_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 -f
       "ci/diagnostic-settings-task/Dockerfile" ./control_plane
+# Verifies the scaling-task Docker image (for CAJ control plane) builds successfully
 scaling-task-test-build:
   image: $DOCKER_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 -f "ci/scaling-task/Dockerfile"
       ./control_plane
+# Packages the control plane Function App tasks into zip artifacts for deployment
 build-tasks:
   image: $CI_IMAGE
   stage: build
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main
@@ -108,10 +120,11 @@ build-tasks:
       - dist/resources_task.zip
       - dist/scaling_task.zip
       - dist/initial_run.sh
+# Uploads control plane Function App task zips and their SHA256 manifest to the public storage account (manual)
 publish-tasks:
   image: $CI_IMAGE
   stage: publish
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: manual
@@ -121,10 +134,11 @@ publish-tasks:
     - control_plane/scripts/publish.py https://ddazurelfo.blob.core.windows.net
   dependencies:
     - build-tasks
+# Publishes control plane task image manifest to the public storage account so deployer-caj knows which images to deploy (manual)
 publish-task-images:
   image: $CI_IMAGE
   stage: publish
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: manual
@@ -137,10 +151,11 @@ publish-task-images:
   script:
     - control_plane/scripts/publish_images.py https://ddazurelfo.blob.core.windows.net
       $INTERNAL_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+# Uploads the uninstall script to the public storage account (manual)
 uninstall-script-publish:
   image: $CI_IMAGE
   stage: publish
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: manual
@@ -149,18 +164,20 @@ uninstall-script-publish:
   script:
     - ./ci/scripts/arm-template/upload-public.sh
       ./control_plane/scripts/uninstall.py uninstall uninstall.py
+# Builds the deployer (Function App) image and pushes it to the internal registry with a versioned tag
 deployer-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 --build-arg
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $INTERNAL_DOCKER_REGISTRY/deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
       -f "ci/deployer-task/Dockerfile" ./control_plane --push
+# Promotes the deployer (Function App) image from the internal registry to the public Azure registry (manual)
 deployer-publish:
   stage: publish
   rules:
@@ -177,18 +194,20 @@ deployer-publish:
     IMG_DESTINATIONS: deployer:latest,deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
+# Builds the deployer-caj image and pushes it to the internal registry with a versioned tag
 deployer-caj-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 --build-arg
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $INTERNAL_DOCKER_REGISTRY/deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
       -f "ci/deployer-caj-task/Dockerfile" ./control_plane --push
+# Promotes the deployer-caj image from the internal registry to the public Azure registry (manual)
 deployer-caj-publish:
   stage: publish
   rules:
@@ -205,18 +224,20 @@ deployer-caj-publish:
     IMG_DESTINATIONS: deployer-caj:latest,deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
+# Builds the resources-task image and pushes it to the internal registry with a versioned tag
 resources-task-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 --build-arg
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $INTERNAL_DOCKER_REGISTRY/resources-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
       -f "ci/resources-task/Dockerfile" ./control_plane --push
+# Promotes the resources-task image from the internal registry to the public Azure registry (manual)
 resources-task-publish:
   stage: publish
   rules:
@@ -233,18 +254,20 @@ resources-task-publish:
     IMG_DESTINATIONS: resources-task:latest,resources-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
+# Builds the diagnostic-settings-task image and pushes it to the internal registry with a versioned tag
 diagnostic-settings-task-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 --build-arg
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $INTERNAL_DOCKER_REGISTRY/diagnostic-settings-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
       -f "ci/diagnostic-settings-task/Dockerfile" ./control_plane --push
+# Promotes the diagnostic-settings-task image from the internal registry to the public Azure registry (manual)
 diagnostic-settings-task-publish:
   stage: publish
   rules:
@@ -261,18 +284,20 @@ diagnostic-settings-task-publish:
     IMG_DESTINATIONS: diagnostic-settings-task:latest,diagnostic-settings-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
+# Builds the scaling-task image and pushes it to the internal registry with a versioned tag
 scaling-task-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 --build-arg
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $INTERNAL_DOCKER_REGISTRY/scaling-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
       -f "ci/scaling-task/Dockerfile" ./control_plane --push
+# Promotes the scaling-task image from the internal registry to the public Azure registry (manual)
 scaling-task-publish:
   stage: publish
   rules:
@@ -290,25 +315,28 @@ scaling-task-publish:
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
 # ------------- FORWARDER -------------
+# Runs the forwarder Go test suite and uploads a coverage report artifact
 forwarder-tests:
   image: $CI_IMAGE
   stage: test
-  tags: [ "docker-in-docker:amd64" ]
+  tags: ["docker-in-docker:amd64"]
   script:
     - ci/scripts/forwarder/test.sh
   artifacts:
     paths:
       - ci/forwarder_coverage.md
+# Verifies the forwarder Docker image builds successfully
 forwarder-test-build:
   image: $DOCKER_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - docker buildx build --platform=linux/amd64 ./forwarder
+# Builds the forwarder image and pushes it to the internal registry with a versioned tag
 forwarder-build-tagged:
   image: $DOCKER_IMAGE
   stage: build
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main
@@ -316,6 +344,7 @@ forwarder-build-tagged:
     - ci/scripts/forwarder/build_and_push.sh $INTERNAL_DOCKER_REGISTRY
       v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
       v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+# Promotes the forwarder image from the internal registry to the public Azure registry (manual)
 forwarder-publish:
   stage: publish
   rules:
@@ -332,33 +361,37 @@ forwarder-publish:
     IMG_DESTINATIONS: forwarder:latest,forwarder:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
+# Checks that go.mod and go.sum are tidy (no missing or extra dependencies)
 forwarder-tidy:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - cd forwarder
     - go mod tidy
     - git diff --exit-code
+# Runs go vet on the forwarder to catch common Go mistakes
 forwarder-vet:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - cd forwarder
     - go vet ./...
+# Checks that forwarder Go code is formatted with gofmt
 forwarder-format:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - cd forwarder
     - go fmt ./...
     - git diff --exit-code
+# Ensures all source files have the required copyright header
 copyright-headers:
   image: $CI_IMAGE
   stage: test
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   dependencies:
     - control-plane-formatting
     - forwarder-vet
@@ -366,10 +399,11 @@ copyright-headers:
     - ci/scripts/licensing/add_copyright_header.py
     - git diff --exit-code
 # ------------- CODE COV -------------
+# Posts a combined test coverage comment on the PR
 coverage-comment:
   image: $PR_COMMENTER_IMAGE
   stage: build
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH != "main"
       allow_failure: true
@@ -379,10 +413,11 @@ coverage-comment:
   script:
     - ci/scripts/coverage-comment.sh
 # ------------- QA ENV -------------
+# Builds the forwarder image and pushes it to the QA registry
 forwarder-build-qa:
   image: $DOCKER_IMAGE
   stage: build
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main
@@ -391,10 +426,11 @@ forwarder-build-qa:
       kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
     - ci/scripts/forwarder/build_and_push.sh $QA_DOCKER_REGISTRY latest
       v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+# Uploads task zips and their SHA256 manifest to the QA storage account
 publish-tasks-qa:
   image: $CI_IMAGE
   stage: publish-qa
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main
@@ -408,10 +444,11 @@ publish-tasks-qa:
     - control_plane/scripts/publish.py https://lfoqa.blob.core.windows.net
   dependencies:
     - build-tasks
+# Publishes the task images manifest to the QA storage account so deployer-caj knows which images to deploy
 publish-task-images-qa:
   image: $CI_IMAGE
   stage: publish-qa
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main
@@ -428,10 +465,11 @@ publish-task-images-qa:
     - resources-task-build-tagged
     - scaling-task-build-tagged
     - diagnostic-settings-task-build-tagged
+# Deploys the QA environment using the latest published task artifacts
 deploy-qa-env:
   image: $CI_IMAGE
   stage: publish-qa
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main
@@ -439,13 +477,14 @@ deploy-qa-env:
     - publish-tasks-qa
   script:
     - ci/scripts/deploy/deploy_qa_env.sh
+# Builds the deployer (FA) image and pushes it to the QA registry
 deployer-build-qa:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - $(vault kv get -field=docker
       kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
@@ -453,13 +492,14 @@ deployer-build-qa:
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $QA_DOCKER_REGISTRY/deployer:latest -f "ci/deployer-task/Dockerfile"
       ./control_plane --push
+# Builds the deployer-caj image and pushes it to the QA registry
 deployer-caj-build-qa:
   image: $DOCKER_IMAGE
   stage: build
   only:
     refs:
       - main
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   script:
     - $(vault kv get -field=docker
       kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
@@ -467,10 +507,11 @@ deployer-caj-build-qa:
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $QA_DOCKER_REGISTRY/deployer-caj:latest -f "ci/deployer-caj-task/Dockerfile"
       ./control_plane --push
+# Uploads the uninstall script to the QA storage account
 uninstall-script-publish-qa:
   image: $CI_IMAGE
   stage: publish-qa
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   only:
     refs:
       - main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,13 @@ deployer-test-build:
   script:
     - docker buildx build --platform=linux/amd64 -f
       "ci/deployer-task/Dockerfile" ./control_plane
+deployer-caj-test-build:
+  image: $DOCKER_IMAGE
+  stage: test
+  tags: [ "arch:amd64" ]
+  script:
+    - docker buildx build --platform=linux/amd64 -f
+      "ci/deployer-caj-task/Dockerfile" ./control_plane
 resources-task-test-build:
   image: $DOCKER_IMAGE
   stage: test
@@ -152,6 +159,34 @@ deployer-publish:
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: deployer:latest,deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_SIGNING: "false"
+    IMG_REGISTRIES: public-azure
+deployer-caj-build-tagged:
+  image: $DOCKER_IMAGE
+  stage: build
+  only:
+    refs:
+      - main
+  tags: [ "arch:amd64" ]
+  script:
+    - docker buildx build --platform=linux/amd64 --build-arg
+      VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
+      $INTERNAL_DOCKER_REGISTRY/deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      -f "ci/deployer-caj-task/Dockerfile" ./control_plane --push
+deployer-caj-publish:
+  stage: publish
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: manual
+  needs:
+    - deployer-caj-build-tagged
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: deployer-caj:latest,deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_SIGNING: "false"
     IMG_REGISTRIES: public-azure
 resources-task-build-tagged:
@@ -381,6 +416,20 @@ deployer-build-qa:
     - docker buildx build --platform=linux/amd64 --build-arg
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $QA_DOCKER_REGISTRY/deployer:latest -f "ci/deployer-task/Dockerfile"
+      ./control_plane --push
+deployer-caj-build-qa:
+  image: $DOCKER_IMAGE
+  stage: build
+  only:
+    refs:
+      - main
+  tags: [ "arch:amd64" ]
+  script:
+    - $(vault kv get -field=docker
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - docker buildx build --platform=linux/amd64 --build-arg
+      VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
+      $QA_DOCKER_REGISTRY/deployer-caj:latest -f "ci/deployer-caj-task/Dockerfile"
       ./control_plane --push
 uninstall-script-publish-qa:
   image: $CI_IMAGE

--- a/ci/deployer-caj-task/Dockerfile
+++ b/ci/deployer-caj-task/Dockerfile
@@ -1,0 +1,18 @@
+FROM registry.ddbuild.io/images/mirror/python:3.11.5-alpine3.18
+
+RUN mkdir /app
+WORKDIR /app
+# Download dependencies
+RUN pip install --upgrade pip
+COPY ./pyproject.toml ./pyproject.toml
+RUN python3.11 -m pip install -e '.[deployer_caj_task]'
+
+# Copy the code into the container
+COPY ./cache ./cache
+COPY ./tasks ./tasks
+
+# Set the version
+ARG VERSION_TAG="latest"
+ENV VERSION_TAG=$VERSION_TAG
+
+CMD ["python3.11", "-m", "tasks.container_app_jobs_deployer_task"]

--- a/control_plane/cache/manifest_cache.py
+++ b/control_plane/cache/manifest_cache.py
@@ -10,9 +10,8 @@ from cache.common import deserialize_cache
 
 ControlPlaneComponent: TypeAlias = Literal["resources", "scaling", "diagnostic_settings"]
 ManifestCache: TypeAlias = dict[ControlPlaneComponent, str]
-"""Mapping of deployable name to SHA-256 manifest"""
 
-
+"""Mapping of deployable name to version data (SHA256 of zip file or image tag)"""
 MANIFEST_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -23,17 +22,17 @@ MANIFEST_SCHEMA: dict[str, Any] = {
     "required": ["resources", "diagnostic_settings", "scaling"],
     "additionalProperties": True,
 }
-
-MANIFEST_CACHE_NAME = "manifest.json"
+ALL_COMPONENTS = frozenset({"resources", "scaling", "diagnostic_settings"})
 
 
 PUBLIC_STORAGE_ACCOUNT_URL = "https://ddazurelfo.blob.core.windows.net"
 TASKS_CONTAINER = "lfo"
+TASK_IMAGES_TASK_ZIPS_MANIFEST_FILE_NAME = "task_images_manifest.json"
+TASK_ZIPS_MANIFEST_FILE_NAME = "manifest.json"
 
 RESOURCES_TASK_ZIP = "resources_task.zip"
 SCALING_TASK_ZIP = "scaling_task.zip"
 DIAGNOSTIC_SETTINGS_TASK_ZIP = "diagnostic_settings_task.zip"
-MANIFEST_FILE_NAME = "manifest.json"
 
 KEY_TO_ZIP: dict[ControlPlaneComponent, str] = {
     "resources": RESOURCES_TASK_ZIP,
@@ -42,7 +41,6 @@ KEY_TO_ZIP: dict[ControlPlaneComponent, str] = {
 }
 
 ALL_ZIPS = frozenset(KEY_TO_ZIP.values())
-ALL_COMPONENTS = frozenset(KEY_TO_ZIP)
 
 
 def prune_manifest_cache(manifest_cache: ManifestCache) -> ManifestCache:

--- a/control_plane/cache/manifest_cache.py
+++ b/control_plane/cache/manifest_cache.py
@@ -27,7 +27,7 @@ ALL_COMPONENTS = frozenset({"resources", "scaling", "diagnostic_settings"})
 
 PUBLIC_STORAGE_ACCOUNT_URL = "https://ddazurelfo.blob.core.windows.net"
 TASKS_CONTAINER = "lfo"
-TASK_IMAGES_TASK_ZIPS_MANIFEST_FILE_NAME = "task_images_manifest.json"
+TASK_IMAGES_MANIFEST_FILE_NAME = "task_images_manifest.json"
 TASK_ZIPS_MANIFEST_FILE_NAME = "manifest.json"
 
 RESOURCES_TASK_ZIP = "resources_task.zip"

--- a/control_plane/cache/tests/test_manifest_cache.py
+++ b/control_plane/cache/tests/test_manifest_cache.py
@@ -11,13 +11,21 @@ from cache.manifest_cache import deserialize_manifest_cache
 
 class TestManifestCache(TestCase):
     def test_validate_manifest_cache_normal(self):
-        original_cache = {
+        original_zip_cache = {
             "resources": "08619d70937787adcea83e7d0b739f7f56ab932e07c8874c9894eec26a7417f3",
             "diagnostic_settings": "7e4765d9c184a79b2916aca3a80ae4110cd0d51486d64b9904cfaa6b44a950c8",
             "scaling": "de03f63c0058dc96964e426b1590eaf8234de9e52280c27bfeee496d1b2d342f",
         }
-        manifest_cache_str = dumps(original_cache)
-        self.assertEqual(original_cache, deserialize_manifest_cache(manifest_cache_str))
+        manifest_cache_str = dumps(original_zip_cache)
+        self.assertEqual(original_zip_cache, deserialize_manifest_cache(manifest_cache_str))
+
+        original_image_cache = {
+            "resources": "v1234-abcd",
+            "diagnostic_settings": "v2345-bcde",
+            "scaling": "v3456-cdef",
+        }
+        manifest_cache_str = dumps(original_image_cache)
+        self.assertEqual(original_image_cache, deserialize_manifest_cache(manifest_cache_str))
 
     def test_validate_manifest_cache_numbers(self):
         original_cache = {
@@ -29,27 +37,51 @@ class TestManifestCache(TestCase):
         self.assertIsNone(deserialize_manifest_cache(manifest_cache_str))
 
     def test_validate_manifest_cache_missing_entry(self):
-        original_cache = {
+        original_zip_cache = {
             "resources": "08619d70937787adcea83e7d0b739f7f56ab932e07c8874c9894eec26a7417f3",
             "diagnostic_settings": "7e4765d9c184a79b2916aca3a80ae4110cd0d51486d64b9904cfaa6b44a950c8",
         }
-        manifest_cache_str = dumps(original_cache)
+        manifest_cache_str = dumps(original_zip_cache)
+        self.assertIsNone(deserialize_manifest_cache(manifest_cache_str))
+
+        original_image_cache = {
+            "resources": "v1234-abcd",
+            "scaling": "v3456-cdef",
+        }
+        manifest_cache_str = dumps(original_image_cache)
         self.assertIsNone(deserialize_manifest_cache(manifest_cache_str))
 
     def test_prune_cache(self):
-        original_cache = {
+        original_zip_cache = {
             "resources": "08619d70937787adcea83e7d0b739f7f56ab932e07c8874c9894eec26a7417f3",
             "diagnostic_settings": "7e4765d9c184a79b2916aca3a80ae4110cd0d51486d64b9904cfaa6b44a950c8",
             "scaling": "de03f63c0058dc96964e426b1590eaf8234de9e52280c27bfeee496d1b2d342f",
             "something_else": "90eaf8234de9e52280c27bfeee496d1b2d342fde03f63c0058dc96964e426b15",
         }
-        manifest_cache_str = dumps(original_cache)
+        manifest_cache_str = dumps(original_zip_cache)
         cache = deserialize_manifest_cache(manifest_cache_str)
         self.assertEqual(
             {
                 "resources": "08619d70937787adcea83e7d0b739f7f56ab932e07c8874c9894eec26a7417f3",
                 "diagnostic_settings": "7e4765d9c184a79b2916aca3a80ae4110cd0d51486d64b9904cfaa6b44a950c8",
                 "scaling": "de03f63c0058dc96964e426b1590eaf8234de9e52280c27bfeee496d1b2d342f",
+            },
+            cache,
+        )
+
+        original_image_cache = {
+            "resources": "v1234-abcd",
+            "diagnostic_settings": "v2345-bcde",
+            "scaling": "v3456-cdef",
+            "something_else": "v5678-asdf",
+        }
+        manifest_cache_str = dumps(original_image_cache)
+        cache = deserialize_manifest_cache(manifest_cache_str)
+        self.assertEqual(
+            {
+                "resources": "v1234-abcd",
+                "diagnostic_settings": "v2345-bcde",
+                "scaling": "v3456-cdef",
             },
             cache,
         )

--- a/control_plane/pyproject.toml
+++ b/control_plane/pyproject.toml
@@ -41,9 +41,12 @@ deployer_task = [
     "azure-mgmt-web==8.0.0",
     "tenacity==9.1.2",
 ]
+deployer_caj_task = [
+    "azure-mgmt-appcontainers==3.2.0",
+]
 
 dev = [
-    "azure-log-forwarding-orchestration[resources_task,diagnostic_settings_task,scaling_task,deployer_task]",
+    "azure-log-forwarding-orchestration[resources_task,diagnostic_settings_task,scaling_task,deployer_task,deployer_caj_task]",
     "pre-commit==4.2.0",
     "pytest==9.0.3",
     "coverage==7.8.0",

--- a/control_plane/scripts/blob_publishing.py
+++ b/control_plane/scripts/blob_publishing.py
@@ -12,7 +12,9 @@ from cache.manifest_cache import PUBLIC_STORAGE_ACCOUNT_URL
 getLogger("azure").setLevel(WARNING)
 
 
-def get_container_client(storage_account_url: str, container: str, connection_string: str | None = None) -> ContainerClient:
+def get_container_client(
+    storage_account_url: str, container: str, connection_string: str | None = None
+) -> ContainerClient:
     if connection_string is not None:
         return BlobServiceClient.from_connection_string(connection_string).get_container_client(container)
     return ContainerClient(storage_account_url, container, DefaultAzureCredential())

--- a/control_plane/scripts/blob_publishing.py
+++ b/control_plane/scripts/blob_publishing.py
@@ -1,0 +1,28 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2 License.
+
+# This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
+
+from logging import WARNING, getLogger
+
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+from cache.manifest_cache import PUBLIC_STORAGE_ACCOUNT_URL
+
+getLogger("azure").setLevel(WARNING)
+
+
+def get_container_client(storage_account_url: str, container: str, connection_string: str | None = None) -> ContainerClient:
+    if connection_string is not None:
+        return BlobServiceClient.from_connection_string(connection_string).get_container_client(container)
+    return ContainerClient(storage_account_url, container, DefaultAzureCredential())
+
+
+def ensure_container_exists(client: ContainerClient, storage_account_url: str) -> None:
+    log = getLogger(__name__)
+    if not client.exists():
+        log.warning("Container %s does not exist, creating it...", client.container_name)
+        if storage_account_url == PUBLIC_STORAGE_ACCOUNT_URL:
+            client.create_container(public_access="container")
+        else:
+            client.create_container()

--- a/control_plane/scripts/publish.py
+++ b/control_plane/scripts/publish.py
@@ -20,13 +20,15 @@ from azure.storage.blob import BlobServiceClient, ContainerClient
 from cache.manifest_cache import (
     ALL_ZIPS,
     DIAGNOSTIC_SETTINGS_TASK_ZIP,
-    MANIFEST_FILE_NAME,
     PUBLIC_STORAGE_ACCOUNT_URL,
     RESOURCES_TASK_ZIP,
     SCALING_TASK_ZIP,
+    TASK_ZIPS_MANIFEST_FILE_NAME,
     TASKS_CONTAINER,
     ManifestCache,
 )
+
+# TODO update this file
 
 if len(sys.argv) < 2:
     print("Usage: publish.py <public_storage_account_url>")
@@ -77,7 +79,7 @@ with ThreadPoolExecutor() as executor:
         else:
             client.create_container()
     futures = [executor.submit(client.upload_blob, filename, data, overwrite=True) for filename, data in files.items()]
-    futures.append(executor.submit(client.upload_blob, MANIFEST_FILE_NAME, dumps(hashes), overwrite=True))
+    futures.append(executor.submit(client.upload_blob, TASK_ZIPS_MANIFEST_FILE_NAME, dumps(hashes), overwrite=True))
     exceptions = [e for f in futures if (e := f.exception())]
     for e in exceptions:
         log.error("An error occurred while uploading a file", exc_info=e)

--- a/control_plane/scripts/publish.py
+++ b/control_plane/scripts/publish.py
@@ -11,16 +11,13 @@ from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
 from itertools import chain
 from json import dumps
-from logging import INFO, WARNING, basicConfig, getLogger
+from logging import INFO, basicConfig, getLogger
 
-# 3p
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient, ContainerClient
+from blob_publishing import ensure_container_exists, get_container_client
 
 from cache.manifest_cache import (
     ALL_ZIPS,
     DIAGNOSTIC_SETTINGS_TASK_ZIP,
-    PUBLIC_STORAGE_ACCOUNT_URL,
     RESOURCES_TASK_ZIP,
     SCALING_TASK_ZIP,
     TASK_ZIPS_MANIFEST_FILE_NAME,
@@ -36,7 +33,6 @@ storage_account_url = sys.argv[1]
 
 basicConfig(level=INFO)
 log = getLogger("publish")
-getLogger("azure").setLevel(WARNING)
 
 log.info("Reading artifacts from dist/")
 files: dict[str, bytes] = {}
@@ -58,24 +54,13 @@ log.info(
     "\n".join(files),
 )
 
-cred = DefaultAzureCredential()
-
-
-client = ContainerClient(storage_account_url, TASKS_CONTAINER, cred)
-if len(sys.argv) >= 3:
-    blob_client = BlobServiceClient.from_connection_string(sys.argv[2])
-    client = blob_client.get_container_client(TASKS_CONTAINER)
-
+connection_string = sys.argv[2] if len(sys.argv) >= 3 else None
+client = get_container_client(storage_account_url, TASKS_CONTAINER, connection_string)
 
 with ThreadPoolExecutor() as executor:
-    if not client.exists():
-        log.warning("Container %s does not exist, creating it...", TASKS_CONTAINER)
-        # The public storage account needs public container access, but storage accounts
-        # created for personal environments can't have public access.
-        if storage_account_url == PUBLIC_STORAGE_ACCOUNT_URL:
-            client.create_container(public_access="container")
-        else:
-            client.create_container()
+    # The public storage account needs public container access, but storage accounts
+    # created for personal environments can't have public access.
+    ensure_container_exists(client, storage_account_url)
     futures = [executor.submit(client.upload_blob, filename, data, overwrite=True) for filename, data in files.items()]
     futures.append(executor.submit(client.upload_blob, TASK_ZIPS_MANIFEST_FILE_NAME, dumps(hashes), overwrite=True))
     exceptions = [e for f in futures if (e := f.exception())]

--- a/control_plane/scripts/publish.py
+++ b/control_plane/scripts/publish.py
@@ -28,8 +28,6 @@ from cache.manifest_cache import (
     ManifestCache,
 )
 
-# TODO update this file
-
 if len(sys.argv) < 2:
     print("Usage: publish.py <public_storage_account_url>")
     sys.exit(1)

--- a/control_plane/scripts/publish_images.py
+++ b/control_plane/scripts/publish_images.py
@@ -8,14 +8,11 @@
 # stdlib
 import sys
 from json import dumps
-from logging import INFO, WARNING, basicConfig, getLogger
+from logging import INFO, basicConfig, getLogger
 
-# 3p
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient, ContainerClient
+from blob_publishing import ensure_container_exists, get_container_client
 
 from cache.manifest_cache import (
-    PUBLIC_STORAGE_ACCOUNT_URL,
     TASK_IMAGES_MANIFEST_FILE_NAME,
     TASKS_CONTAINER,
     ManifestCache,
@@ -31,7 +28,6 @@ version_tag = sys.argv[3]
 
 basicConfig(level=INFO)
 log = getLogger("publish_images")
-getLogger("azure").setLevel(WARNING)
 
 manifest: ManifestCache = {
     "resources": f"{registry}/resources-task:{version_tag}",
@@ -47,18 +43,9 @@ log.info(
     manifest,
 )
 
-cred = DefaultAzureCredential()
-client = ContainerClient(storage_account_url, TASKS_CONTAINER, cred)
-if len(sys.argv) >= 5:
-    blob_client = BlobServiceClient.from_connection_string(sys.argv[4])
-    client = blob_client.get_container_client(TASKS_CONTAINER)
-
-if not client.exists():
-    log.warning("Container %s does not exist, creating it...", TASKS_CONTAINER)
-    if storage_account_url == PUBLIC_STORAGE_ACCOUNT_URL:
-        client.create_container(public_access="container")
-    else:
-        client.create_container()
+connection_string = sys.argv[4] if len(sys.argv) >= 5 else None
+client = get_container_client(storage_account_url, TASKS_CONTAINER, connection_string)
+ensure_container_exists(client, storage_account_url)
 
 client.upload_blob(TASK_IMAGES_MANIFEST_FILE_NAME, dumps(manifest), overwrite=True)
 log.info("Done publishing task images manifest to %s/%s", storage_account_url, TASKS_CONTAINER)

--- a/control_plane/scripts/publish_images.py
+++ b/control_plane/scripts/publish_images.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2 License.
+
+# This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
+
+# usage: publish_images.py <public_storage_account_url> <registry> <version_tag>
+
+# stdlib
+import sys
+from json import dumps
+from logging import INFO, WARNING, basicConfig, getLogger
+
+# 3p
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+from cache.manifest_cache import (
+    PUBLIC_STORAGE_ACCOUNT_URL,
+    TASK_IMAGES_MANIFEST_FILE_NAME,
+    TASKS_CONTAINER,
+    ManifestCache,
+)
+
+if len(sys.argv) < 4:
+    print("Usage: publish_images.py <public_storage_account_url> <registry> <version_tag>")
+    sys.exit(1)
+
+storage_account_url = sys.argv[1]
+registry = sys.argv[2]
+version_tag = sys.argv[3]
+
+basicConfig(level=INFO)
+log = getLogger("publish_images")
+getLogger("azure").setLevel(WARNING)
+
+manifest: ManifestCache = {
+    "resources": f"{registry}/resources-task:{version_tag}",
+    "scaling": f"{registry}/scaling-task:{version_tag}",
+    "diagnostic_settings": f"{registry}/diagnostic-settings-task:{version_tag}",
+}
+
+log.info(
+    "Publishing task images manifest to %s/%s/%s:\n%s",
+    storage_account_url,
+    TASKS_CONTAINER,
+    TASK_IMAGES_MANIFEST_FILE_NAME,
+    manifest,
+)
+
+cred = DefaultAzureCredential()
+client = ContainerClient(storage_account_url, TASKS_CONTAINER, cred)
+if len(sys.argv) >= 5:
+    blob_client = BlobServiceClient.from_connection_string(sys.argv[4])
+    client = blob_client.get_container_client(TASKS_CONTAINER)
+
+if not client.exists():
+    log.warning("Container %s does not exist, creating it...", TASKS_CONTAINER)
+    if storage_account_url == PUBLIC_STORAGE_ACCOUNT_URL:
+        client.create_container(public_access="container")
+    else:
+        client.create_container()
+
+client.upload_blob(TASK_IMAGES_MANIFEST_FILE_NAME, dumps(manifest), overwrite=True)
+log.info("Done publishing task images manifest to %s/%s", storage_account_url, TASKS_CONTAINER)

--- a/control_plane/tasks/container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/container_app_jobs_deployer_task.py
@@ -15,8 +15,8 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.appcontainers.aio import ContainerAppsAPIClient
 from azure.mgmt.appcontainers.models import Container, JobPatchProperties, JobPatchPropertiesProperties, JobTemplate
 from azure.storage.blob.aio import ContainerClient
-from control_plane.cache.common import InvalidCacheError, read_cache, write_cache
-from control_plane.tasks.concurrency import collect
+
+from cache.common import InvalidCacheError, read_cache, write_cache
 
 # project
 from cache.env import (
@@ -41,6 +41,7 @@ from tasks.common import (
     Resource,
     get_azure_mgmt_url,
 )
+from tasks.concurrency import collect
 from tasks.task import Task, task_main
 
 CAJ_DEPLOYER_TASK_NAME = "container_app_jobs_deployer_task"

--- a/control_plane/tasks/container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/container_app_jobs_deployer_task.py
@@ -4,7 +4,6 @@
 
 # stdlib
 from asyncio import gather, run
-from json import dumps
 from os import environ
 from types import TracebackType
 from typing import Self, cast
@@ -13,11 +12,17 @@ from typing import Self, cast
 from aiohttp import ClientSession
 from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.appcontainers.aio import ContainerAppsAPIClient
-from azure.mgmt.appcontainers.models import Container, JobPatchProperties, JobPatchPropertiesProperties, JobTemplate
+from azure.mgmt.appcontainers.models import (
+    Container,
+    Job,
+    JobPatchProperties,
+    JobPatchPropertiesProperties,
+    JobTemplate,
+)
 from azure.storage.blob.aio import ContainerClient
 
 # project
-from cache.common import InvalidCacheError, read_cache, write_cache
+from cache.common import InvalidCacheError
 from cache.env import (
     CONTROL_PLANE_REGION_SETTING,
     RESOURCE_GROUP_SETTING,
@@ -37,13 +42,18 @@ from tasks.common import (
     DIAGNOSTIC_SETTINGS_TASK_PREFIX,
     RESOURCES_TASK_PREFIX,
     SCALING_TASK_PREFIX,
-    Resource,
     get_azure_mgmt_url,
 )
 from tasks.concurrency import collect
 from tasks.task import Task, task_main
 
 CAJ_DEPLOYER_TASK_NAME = "container_app_jobs_deployer_task"
+
+COMPONENT_TASK_PREFIXES: dict[ControlPlaneComponent, str] = {
+    "resources": RESOURCES_TASK_PREFIX,
+    "scaling": SCALING_TASK_PREFIX,
+    "diagnostic_settings": DIAGNOSTIC_SETTINGS_TASK_PREFIX,
+}
 
 
 class DeployError(Exception):
@@ -95,37 +105,26 @@ class ContainerAppJobsDeployerTask(Task):
         await super().__aexit__(exc_type, exc_val, exc_tb)
 
     async def run(self) -> None:
-        public_manifest, private_manifest, current_control_plane_jobs = await gather(
-            self.get_public_manifests(), self.get_private_manifests(), self.get_control_plane_jobs()
+        public_manifest, current_control_plane_jobs = await gather(
+            self.get_public_manifests(), self.get_control_plane_jobs()
         )
 
-        if not private_manifest:
-            self.log.warning("Failed to read private manifest. Deploying all components.")
-        self.public_manifest = public_manifest
-        self.private_manifest = private_manifest
-        self.manifest_cache = (
-            private_manifest
-            or {
-                "resources": "",
-                "scaling": "",
-                "diagnostic_settings": "",
-            }
-        ).copy()
+        components_to_update: dict[ControlPlaneComponent, tuple[Job, str]] = {
+            component: (job, new_image)
+            for component, new_image in public_manifest.items()
+            if (job := current_control_plane_jobs.get(component)) is not None
+            and self.get_current_image(component, job) != new_image
+        }
 
-        components_to_update: ManifestCache
-        if not private_manifest:
-            components_to_update = public_manifest
-        else:
-            components_to_update = {
-                component: new_image
-                for component, new_image in public_manifest.items()
-                if private_manifest.get(component) != new_image
-            }
+        missing_components = public_manifest.keys() - current_control_plane_jobs.keys()
+        for component in missing_components:
+            self.log.error(f"Container app job for {component} not found, skipping update")
+
         if components_to_update:
             await gather(
                 *[
-                    self.update_task_image(component, new_image, current_control_plane_jobs)
-                    for component, new_image in components_to_update.items()
+                    self.update_task_image(component, job, new_image)
+                    for component, (job, new_image) in components_to_update.items()
                 ]
             )
         else:
@@ -142,42 +141,29 @@ class ContainerAppJobsDeployerTask(Task):
             raise InvalidCacheError(f"Invalid Public Manifest: {cache_str}")
         return cache
 
-    async def get_private_manifests(self) -> ManifestCache | None:
-        try:
-            blob_data = await read_cache(TASK_IMAGES_MANIFEST_FILE_NAME)
-        except Exception:
-            self.log.exception("Error reading private manifest cache")
-            return None
-        return deserialize_manifest_cache(blob_data)
-
-    async def get_control_plane_jobs(self) -> set[str]:
+    async def get_control_plane_jobs(self) -> dict[ControlPlaneComponent, Job]:
         current_jobs = await collect(self.container_apps_client.jobs.list_by_resource_group(self.resource_group))
-        return {
-            task.name
-            for task in cast(list[Resource], current_jobs)
-            if any(
-                task.name.startswith(prefix)
-                for prefix in (SCALING_TASK_PREFIX, RESOURCES_TASK_PREFIX, DIAGNOSTIC_SETTINGS_TASK_PREFIX)
-            )
-        }
+        jobs_by_component: dict[ControlPlaneComponent, Job] = {}
+        for job in cast(list[Job], current_jobs):
+            for component, prefix in COMPONENT_TASK_PREFIXES.items():
+                if job.name and job.name.startswith(prefix):
+                    jobs_by_component[component] = job
+                    break
+        return jobs_by_component
 
-    async def update_task_image(
-        self, component: ControlPlaneComponent, new_image: str, current_job_names: set[str]
-    ) -> None:
-        task_prefix = f"{component.replace('_', '-')}-task-"
+    def get_current_image(self, component: ControlPlaneComponent, job: Job) -> str | None:
         container_name = f"{component.replace('_', '-')}-task"
-        job_name = next((app for app in current_job_names if app.startswith(task_prefix)), None)
-        if not job_name:
-            self.log.error(f"Container app job for {component} not found in {current_job_names}, skipping update")
-            return
+        containers = job.template.containers if job.template else None
+        return next((container.image for container in containers or [] if container.name == container_name), None)
 
+    async def update_task_image(self, component: ControlPlaneComponent, job: Job, new_image: str) -> None:
+        container_name = f"{component.replace('_', '-')}-task"
         try:
-            self.log.info(f"Updating image of {job_name}")
-            await self.update_container_app_image(job_name, container_name, new_image)
+            self.log.info(f"Updating image of {job.name}")
+            await self.update_container_app_image(cast(str, job.name), container_name, new_image)
         except Exception:
             self.log.exception(f"Failed to update {component}")
             return
-        self.manifest_cache[component] = self.public_manifest[component]
         self.log.info(f"Finished updating {component}")
 
     async def update_container_app_image(self, job_name: str, container_name: str, new_image: str) -> None:
@@ -193,9 +179,7 @@ class ContainerAppJobsDeployerTask(Task):
         await poller.result()
 
     async def write_caches(self) -> None:
-        if self.manifest_cache == self.private_manifest:
-            return
-        await write_cache(TASK_IMAGES_MANIFEST_FILE_NAME, dumps(self.manifest_cache))
+        return
 
 
 if __name__ == "__main__":

--- a/control_plane/tasks/container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/container_app_jobs_deployer_task.py
@@ -16,9 +16,8 @@ from azure.mgmt.appcontainers.aio import ContainerAppsAPIClient
 from azure.mgmt.appcontainers.models import Container, JobPatchProperties, JobPatchPropertiesProperties, JobTemplate
 from azure.storage.blob.aio import ContainerClient
 
-from cache.common import InvalidCacheError, read_cache, write_cache
-
 # project
+from cache.common import InvalidCacheError, read_cache, write_cache
 from cache.env import (
     CONTROL_PLANE_REGION_SETTING,
     RESOURCE_GROUP_SETTING,

--- a/control_plane/tasks/container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/container_app_jobs_deployer_task.py
@@ -1,0 +1,197 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2 License.
+
+# This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
+
+# stdlib
+from asyncio import gather, run
+from json import dumps
+from os import environ
+from types import TracebackType
+from typing import Self, cast
+
+# 3p
+from aiohttp import ClientSession
+from azure.core.exceptions import ResourceNotFoundError
+from azure.mgmt.appcontainers.aio import ContainerAppsAPIClient
+from azure.mgmt.appcontainers.models import Container, JobPatchProperties, JobPatchPropertiesProperties, JobTemplate
+from azure.storage.blob.aio import ContainerClient
+
+# project
+from cache.env import (
+    CONTROL_PLANE_REGION_SETTING,
+    RESOURCE_GROUP_SETTING,
+    STORAGE_ACCOUNT_URL_SETTING,
+    SUBSCRIPTION_ID_SETTING,
+    get_config_option,
+)
+from cache.manifest_cache import (
+    PUBLIC_STORAGE_ACCOUNT_URL,
+    TASK_IMAGES_MANIFEST_FILE_NAME,
+    TASKS_CONTAINER,
+    ControlPlaneComponent,
+    ManifestCache,
+    deserialize_manifest_cache,
+)
+from control_plane.cache.common import InvalidCacheError, read_cache, write_cache
+from control_plane.tasks.concurrency import collect
+from tasks.common import (
+    DIAGNOSTIC_SETTINGS_TASK_PREFIX,
+    RESOURCES_TASK_PREFIX,
+    SCALING_TASK_PREFIX,
+    Resource,
+    get_azure_mgmt_url,
+)
+from tasks.task import Task, task_main
+
+CAJ_DEPLOYER_TASK_NAME = "container_app_jobs_deployer_task"
+
+
+class DeployError(Exception):
+    pass
+
+
+class ContainerAppJobsDeployerTask(Task):
+    NAME = CAJ_DEPLOYER_TASK_NAME
+
+    def __init__(self, is_initial_run: bool = False) -> None:
+        super().__init__()
+        self.subscription_id = get_config_option(SUBSCRIPTION_ID_SETTING)
+        self.resource_group = get_config_option(RESOURCE_GROUP_SETTING)
+        self.region = get_config_option(CONTROL_PLANE_REGION_SETTING)
+        self.rest_client = ClientSession()
+        self.container_apps_client = ContainerAppsAPIClient(
+            self.credential, self.subscription_id, base_url=get_azure_mgmt_url(self.region)
+        )
+
+        storage_account_url = environ.get(STORAGE_ACCOUNT_URL_SETTING, PUBLIC_STORAGE_ACCOUNT_URL)
+        # If authenticating with the public storage account, we use anonymous access since the blobs are public.
+        # In this case, we should not pass a credential to the ContainerClient.
+        # If authenticating with a private storage account (ex. personal environment), we need to pass the credential
+        # of the DeployerTask. It should have Storage Blob Data Contributor role (or similar) on the storage acocunt
+        credential = self.credential if storage_account_url != PUBLIC_STORAGE_ACCOUNT_URL else None
+        self.public_storage_client = ContainerClient(storage_account_url, TASKS_CONTAINER, credential=credential)
+
+    async def __aenter__(self) -> Self:
+        await super().__aenter__()
+        await gather(
+            self.public_storage_client.__aenter__(),
+            self.rest_client.__aenter__(),
+            self.container_apps_client.__aenter__(),
+        )
+        token_scope = get_azure_mgmt_url(self.region) + "/.default"
+        token = await self.credential.get_token(token_scope)
+
+        self.rest_client.headers["Authorization"] = f"Bearer {token.token}"
+        return self
+
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+    ) -> None:
+        await gather(
+            self.public_storage_client.__aexit__(exc_type, exc_val, exc_tb),
+            self.rest_client.__aexit__(exc_type, exc_val, exc_tb),
+            self.container_apps_client.__aexit__(exc_type, exc_val, exc_tb),
+        )
+        await super().__aexit__(exc_type, exc_val, exc_tb)
+
+    async def run(self) -> None:
+        public_manifest, private_manifest, current_control_plane_jobs = await gather(
+            self.get_public_manifests(), self.get_private_manifests(), self.get_control_plane_jobs()
+        )
+
+        if not private_manifest:
+            self.log.warning("Failed to read private manifest. Deploying all components.")
+        self.public_manifest = public_manifest
+        self.private_manifest = private_manifest
+        self.manifest_cache = (
+            private_manifest
+            or {
+                "resources": "",
+                "scaling": "",
+                "diagnostic_settings": "",
+            }
+        ).copy()
+
+        components_to_update: ManifestCache
+        if not private_manifest:
+            components_to_update = public_manifest
+        else:
+            components_to_update = {
+                component: new_image
+                for component, new_image in public_manifest.items()
+                if private_manifest.get(component) != new_image
+            }
+        if components_to_update:
+            await gather(*[self.update_task_image(component, new_image, current_control_plane_jobs) for component, new_image in components_to_update.items()])
+        else:
+            self.log.info("All components are up to date, skipping deployment")
+
+    async def get_public_manifests(self) -> ManifestCache:
+        try:
+            stream = await self.public_storage_client.download_blob(TASK_IMAGES_MANIFEST_FILE_NAME)
+        except ResourceNotFoundError as e:
+            raise InvalidCacheError("Public Manifest not found") from e
+        blob_data = await stream.readall()
+        cache_str = blob_data.decode()
+        if not (cache := deserialize_manifest_cache(cache_str)):
+            raise InvalidCacheError(f"Invalid Public Manifest: {cache_str}")
+        return cache
+
+    async def get_private_manifests(self) -> ManifestCache | None:
+        try:
+            blob_data = await read_cache(TASK_IMAGES_MANIFEST_FILE_NAME)
+        except Exception:
+            self.log.exception("Error reading private manifest cache")
+            return None
+        return deserialize_manifest_cache(blob_data)
+
+    async def get_control_plane_jobs(self) -> set[str]:
+        current_jobs = await collect(self.container_apps_client.jobs.list_by_resource_group(self.resource_group))
+        return {
+            task.name
+            for task in cast(list[Resource], current_jobs)
+            if any(
+                task.name.startswith(prefix)
+                for prefix in (SCALING_TASK_PREFIX, RESOURCES_TASK_PREFIX, DIAGNOSTIC_SETTINGS_TASK_PREFIX)
+            )
+        }
+
+    async def update_task_image(self, component: ControlPlaneComponent, new_image: str, current_job_names: set[str]) -> None:
+        task_prefix = f"{component.replace('_', '-')}-task-"
+        container_name = f"{component.replace('_', '-')}-task"
+        job_name = next((app for app in current_job_names if app.startswith(task_prefix)), None)
+        if not job_name:
+            self.log.error(f"Container app job for {component} not found in {current_job_names}, skipping update")
+            return
+
+        try:
+            self.log.info(f"Updating image of {job_name}")
+            await self.update_container_app_image(job_name, container_name, new_image)
+        except Exception:
+            self.log.exception(f"Failed to update {component}")
+            return
+        self.manifest_cache[component] = self.public_manifest[component]
+        self.log.info(f"Finished updating {component}")
+
+    async def update_container_app_image(self, job_name: str, container_name: str, new_image: str) -> None:
+        poller = await self.container_apps_client.jobs.begin_update(
+            self.resource_group,
+            job_name,
+            JobPatchProperties(
+                properties=JobPatchPropertiesProperties(
+                    template=JobTemplate(
+                        containers=[Container(name=container_name, image=new_image)]
+                    )
+                )
+            ),
+        )
+        await poller.result()
+
+    async def write_caches(self) -> None:
+        if self.manifest_cache == self.private_manifest:
+            return
+        await write_cache(TASK_IMAGES_MANIFEST_FILE_NAME, dumps(self.manifest_cache))
+
+
+if __name__ == "__main__":
+    run(task_main(ContainerAppJobsDeployerTask, []))

--- a/control_plane/tasks/container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/container_app_jobs_deployer_task.py
@@ -15,6 +15,8 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.appcontainers.aio import ContainerAppsAPIClient
 from azure.mgmt.appcontainers.models import Container, JobPatchProperties, JobPatchPropertiesProperties, JobTemplate
 from azure.storage.blob.aio import ContainerClient
+from control_plane.cache.common import InvalidCacheError, read_cache, write_cache
+from control_plane.tasks.concurrency import collect
 
 # project
 from cache.env import (
@@ -32,8 +34,6 @@ from cache.manifest_cache import (
     ManifestCache,
     deserialize_manifest_cache,
 )
-from control_plane.cache.common import InvalidCacheError, read_cache, write_cache
-from control_plane.tasks.concurrency import collect
 from tasks.common import (
     DIAGNOSTIC_SETTINGS_TASK_PREFIX,
     RESOURCES_TASK_PREFIX,
@@ -122,7 +122,12 @@ class ContainerAppJobsDeployerTask(Task):
                 if private_manifest.get(component) != new_image
             }
         if components_to_update:
-            await gather(*[self.update_task_image(component, new_image, current_control_plane_jobs) for component, new_image in components_to_update.items()])
+            await gather(
+                *[
+                    self.update_task_image(component, new_image, current_control_plane_jobs)
+                    for component, new_image in components_to_update.items()
+                ]
+            )
         else:
             self.log.info("All components are up to date, skipping deployment")
 
@@ -156,7 +161,9 @@ class ContainerAppJobsDeployerTask(Task):
             )
         }
 
-    async def update_task_image(self, component: ControlPlaneComponent, new_image: str, current_job_names: set[str]) -> None:
+    async def update_task_image(
+        self, component: ControlPlaneComponent, new_image: str, current_job_names: set[str]
+    ) -> None:
         task_prefix = f"{component.replace('_', '-')}-task-"
         container_name = f"{component.replace('_', '-')}-task"
         job_name = next((app for app in current_job_names if app.startswith(task_prefix)), None)
@@ -179,9 +186,7 @@ class ContainerAppJobsDeployerTask(Task):
             job_name,
             JobPatchProperties(
                 properties=JobPatchPropertiesProperties(
-                    template=JobTemplate(
-                        containers=[Container(name=container_name, image=new_image)]
-                    )
+                    template=JobTemplate(containers=[Container(name=container_name, image=new_image)])
                 )
             ),
         )

--- a/control_plane/tasks/deployer_task.py
+++ b/control_plane/tasks/deployer_task.py
@@ -27,8 +27,8 @@ from cache.env import (
 )
 from cache.manifest_cache import (
     KEY_TO_ZIP,
-    MANIFEST_FILE_NAME,
     PUBLIC_STORAGE_ACCOUNT_URL,
+    TASK_ZIPS_MANIFEST_FILE_NAME,
     TASKS_CONTAINER,
     ControlPlaneComponent,
     ManifestCache,
@@ -125,7 +125,7 @@ class DeployerTask(Task):
     @retry(stop=stop_after_attempt(MAX_ATTEMPTS), retry=retry_if_not_exception_type(InvalidCacheError))
     async def get_public_manifests(self) -> ManifestCache:
         try:
-            stream = await self.public_storage_client.download_blob(MANIFEST_FILE_NAME)
+            stream = await self.public_storage_client.download_blob(TASK_ZIPS_MANIFEST_FILE_NAME)
         except ResourceNotFoundError as e:
             raise InvalidCacheError("Public Manifest not found") from e
         blob_data = await stream.readall()
@@ -136,7 +136,7 @@ class DeployerTask(Task):
 
     async def get_private_manifests(self) -> ManifestCache | None:
         try:
-            blob_data = await retry(stop=stop_after_attempt(MAX_ATTEMPTS))(read_cache)(MANIFEST_FILE_NAME)
+            blob_data = await retry(stop=stop_after_attempt(MAX_ATTEMPTS))(read_cache)(TASK_ZIPS_MANIFEST_FILE_NAME)
         except RetryError as e:
             self.log.error("Error reading private manifest cache", exc_info=e.last_attempt.exception())
             return None
@@ -200,7 +200,7 @@ class DeployerTask(Task):
     async def write_caches(self) -> None:
         if self.manifest_cache == self.private_manifest:
             return
-        await write_cache(MANIFEST_FILE_NAME, dumps(self.manifest_cache))
+        await write_cache(TASK_ZIPS_MANIFEST_FILE_NAME, dumps(self.manifest_cache))
 
 
 if __name__ == "__main__":

--- a/control_plane/tasks/tests/test_container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/tests/test_container_app_jobs_deployer_task.py
@@ -14,24 +14,20 @@ from cache.env import (
     RESOURCE_GROUP_SETTING,
     SUBSCRIPTION_ID_SETTING,
 )
-from cache.manifest_cache import TASK_IMAGES_MANIFEST_FILE_NAME, ManifestCache, deserialize_manifest_cache
+from cache.manifest_cache import TASK_IMAGES_MANIFEST_FILE_NAME, ManifestCache
 from tasks.container_app_jobs_deployer_task import CAJ_DEPLOYER_TASK_NAME, ContainerAppJobsDeployerTask
 from tasks.tests.common import AsyncMockClient, AzureModelMatcher, TaskTestCase, async_generator, mock
 from tasks.version import VERSION
 
-ALL_JOBS = [
-    "resources-task-0863329b4b49",
-    "scaling-task-0863329b4b49",
-    "diagnostic-settings-task-0863329b4b49",
-]
+JOB_NAMES = {
+    "resources": "resources-task-0863329b4b49",
+    "scaling": "scaling-task-0863329b4b49",
+    "diagnostic_settings": "diagnostic-settings-task-0863329b4b49",
+}
 
 
 class TestContainerAppJobsDeployerTask(TaskTestCase):
     TASK_NAME = CAJ_DEPLOYER_TASK_NAME
-
-    @property
-    def cache(self) -> ManifestCache:
-        return self.cache_value(TASK_IMAGES_MANIFEST_FILE_NAME, deserialize_manifest_cache)
 
     def setUp(self) -> None:
         super().setUp()
@@ -46,7 +42,6 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
         self.patch("environ.get").side_effect = lambda k, default="unset test env var": self.env.get(k, default)
         self.public_client = AsyncMockClient()
         self.patch("ContainerClient").return_value = self.public_client
-        self.read_private_cache = self.patch("read_cache")
         self.rest_client = AsyncMockClient()
         self.patch("ClientSession").return_value = self.rest_client
         self.container_apps_client = AsyncMockClient()
@@ -54,14 +49,18 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
         self.container_apps_client.jobs.begin_update = AsyncMock(return_value=AsyncMock())
         self.patch("ContainerAppsAPIClient").return_value = self.container_apps_client
 
-    def set_caches(self, public_cache: ManifestCache, private_cache: ManifestCache) -> None:
+    def set_public_manifest(self, public_cache: ManifestCache) -> None:
         self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
-        self.read_private_cache.return_value = dumps(private_cache)
 
-    def set_current_jobs(self, jobs: list[str]) -> None:
-        self.container_apps_client.jobs.list_by_resource_group.return_value = async_generator(
-            *(mock(name=job) for job in jobs)
-        )
+    def set_current_jobs(self, current_images: dict[str, str]) -> None:
+        """current_images maps component name to the image its container app job is currently running.
+        Components not present in the mapping have no corresponding job."""
+        jobs = []
+        for component, image in current_images.items():
+            job_name = JOB_NAMES[component]
+            container_name = job_name.rsplit("-", 1)[0]
+            jobs.append(mock(name=job_name, template=mock(containers=[mock(name=container_name, image=image)])))
+        self.container_apps_client.jobs.list_by_resource_group.return_value = async_generator(*jobs)
 
     async def run_task(self) -> ContainerAppJobsDeployerTask:
         async with ContainerAppJobsDeployerTask(is_initial_run=False) as task:
@@ -69,23 +68,16 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
         return task
 
     async def test_no_diff(self):
-        self.set_caches(
-            public_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(ALL_JOBS)
+        self.set_public_manifest({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
 
         await self.run_task()
 
         self.container_apps_client.jobs.begin_update.assert_not_awaited()
-        self.write_cache.assert_not_awaited()
 
     async def test_updates_changed_component(self):
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(ALL_JOBS)
+        self.set_public_manifest({"resources": "2", "scaling": "1", "diagnostic_settings": "1"})
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
 
         await self.run_task()
 
@@ -94,72 +86,36 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
             "resources-task-0863329b4b49",
             AzureModelMatcher({"properties": {"template": {"containers": [{"name": "resources-task", "image": "2"}]}}}),
         )
-        self.assertEqual(self.cache, {"resources": "2", "scaling": "1", "diagnostic_settings": "1"})
 
     async def test_updates_multiple_components(self):
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "2", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(ALL_JOBS)
+        self.set_public_manifest({"resources": "2", "scaling": "2", "diagnostic_settings": "1"})
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
 
         await self.run_task()
 
         self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 2)
-        self.assertEqual(self.cache, {"resources": "2", "scaling": "2", "diagnostic_settings": "1"})
-
-    async def test_no_private_manifest(self):
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
-        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
-        self.read_private_cache.return_value = ""
-        self.set_current_jobs(ALL_JOBS)
-
-        await self.run_task()
-
-        self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 3)
-        self.assertEqual(self.cache, public_cache)
 
     async def test_invalid_public_manifest(self):
         self.public_client.download_blob.return_value.readall.return_value = b"invalid"
-        self.read_private_cache.return_value = dumps({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
-        self.set_current_jobs(ALL_JOBS)
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
 
         with self.assertRaises(InvalidCacheError) as ctx:
             await self.run_task()
 
-        self.write_cache.assert_not_awaited()
         self.public_client.download_blob.assert_awaited_once_with(TASK_IMAGES_MANIFEST_FILE_NAME)
         self.assertEqual("Invalid Public Manifest: invalid", str(ctx.exception))
 
-    async def test_private_manifest_error(self):
-        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
-        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
-        self.read_private_cache.side_effect = Exception("storage error")
-        self.set_current_jobs(ALL_JOBS)
-
-        await self.run_task()
-
-        self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 3)
-        self.assertEqual(self.cache, public_cache)
-
     async def test_job_not_found_skips_component(self):
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(["scaling-task-0863329b4b49", "diagnostic-settings-task-0863329b4b49"])
+        self.set_public_manifest({"resources": "2", "scaling": "1", "diagnostic_settings": "1"})
+        self.set_current_jobs({"scaling": "1", "diagnostic_settings": "1"})
 
         await self.run_task()
 
         self.container_apps_client.jobs.begin_update.assert_not_awaited()
-        self.write_cache.assert_not_awaited()
 
-    async def test_update_failure_skips_cache_write_for_component(self):
-        self.set_caches(
-            public_cache={"resources": "2", "scaling": "2", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(ALL_JOBS)
+    async def test_update_failure_does_not_block_other_updates(self):
+        self.set_public_manifest({"resources": "2", "scaling": "2", "diagnostic_settings": "1"})
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
         self.container_apps_client.jobs.begin_update.side_effect = [Exception("update failed"), AsyncMock()]
 
         await self.run_task()
@@ -168,11 +124,8 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
 
     async def test_govcloud(self):
         self.env[CONTROL_PLANE_REGION_SETTING] = "usgovarizona"
-        self.set_caches(
-            public_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(ALL_JOBS)
+        self.set_public_manifest({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
 
         await self.run_task()
 
@@ -181,11 +134,8 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
 
     async def test_tags(self):
         self.env[CONTROL_PLANE_ID_SETTING] = "a2b4c5d6"
-        self.set_caches(
-            public_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
-        )
-        self.set_current_jobs(ALL_JOBS)
+        self.set_public_manifest({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
+        self.set_current_jobs({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
 
         task = await self.run_task()
 

--- a/control_plane/tasks/tests/test_container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/tests/test_container_app_jobs_deployer_task.py
@@ -92,9 +92,7 @@ class TestContainerAppJobsDeployerTask(TaskTestCase):
         self.container_apps_client.jobs.begin_update.assert_awaited_once_with(
             "test_rg",
             "resources-task-0863329b4b49",
-            AzureModelMatcher(
-                {"properties": {"template": {"containers": [{"name": "resources-task", "image": "2"}]}}}
-            ),
+            AzureModelMatcher({"properties": {"template": {"containers": [{"name": "resources-task", "image": "2"}]}}}),
         )
         self.assertEqual(self.cache, {"resources": "2", "scaling": "1", "diagnostic_settings": "1"})
 

--- a/control_plane/tasks/tests/test_container_app_jobs_deployer_task.py
+++ b/control_plane/tasks/tests/test_container_app_jobs_deployer_task.py
@@ -1,0 +1,202 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2 License.
+
+# This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
+
+# stdlib
+from json import dumps
+from unittest.mock import AsyncMock, MagicMock
+
+# project
+from cache.common import InvalidCacheError
+from cache.env import (
+    CONTROL_PLANE_ID_SETTING,
+    CONTROL_PLANE_REGION_SETTING,
+    RESOURCE_GROUP_SETTING,
+    SUBSCRIPTION_ID_SETTING,
+)
+from cache.manifest_cache import TASK_IMAGES_MANIFEST_FILE_NAME, ManifestCache, deserialize_manifest_cache
+from tasks.container_app_jobs_deployer_task import CAJ_DEPLOYER_TASK_NAME, ContainerAppJobsDeployerTask
+from tasks.tests.common import AsyncMockClient, AzureModelMatcher, TaskTestCase, async_generator, mock
+from tasks.version import VERSION
+
+ALL_JOBS = [
+    "resources-task-0863329b4b49",
+    "scaling-task-0863329b4b49",
+    "diagnostic-settings-task-0863329b4b49",
+]
+
+
+class TestContainerAppJobsDeployerTask(TaskTestCase):
+    TASK_NAME = CAJ_DEPLOYER_TASK_NAME
+
+    @property
+    def cache(self) -> ManifestCache:
+        return self.cache_value(TASK_IMAGES_MANIFEST_FILE_NAME, deserialize_manifest_cache)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.env.update(
+            {
+                RESOURCE_GROUP_SETTING: "test_rg",
+                CONTROL_PLANE_REGION_SETTING: "region1",
+                SUBSCRIPTION_ID_SETTING: "0863329b-6e5c-4b49-bb0e-c87fdab76bb2",
+            }
+        )
+        self.patch("get_config_option").side_effect = lambda k: self.env[k]
+        self.patch("environ.get").side_effect = lambda k, default="unset test env var": self.env.get(k, default)
+        self.public_client = AsyncMockClient()
+        self.patch("ContainerClient").return_value = self.public_client
+        self.read_private_cache = self.patch("read_cache")
+        self.rest_client = AsyncMockClient()
+        self.patch("ClientSession").return_value = self.rest_client
+        self.container_apps_client = AsyncMockClient()
+        self.container_apps_client.jobs.list_by_resource_group = MagicMock(return_value=async_generator())
+        self.container_apps_client.jobs.begin_update = AsyncMock(return_value=AsyncMock())
+        self.patch("ContainerAppsAPIClient").return_value = self.container_apps_client
+
+    def set_caches(self, public_cache: ManifestCache, private_cache: ManifestCache) -> None:
+        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
+        self.read_private_cache.return_value = dumps(private_cache)
+
+    def set_current_jobs(self, jobs: list[str]) -> None:
+        self.container_apps_client.jobs.list_by_resource_group.return_value = async_generator(
+            *(mock(name=job) for job in jobs)
+        )
+
+    async def run_task(self) -> ContainerAppJobsDeployerTask:
+        async with ContainerAppJobsDeployerTask(is_initial_run=False) as task:
+            await task.run()
+        return task
+
+    async def test_no_diff(self):
+        self.set_caches(
+            public_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(ALL_JOBS)
+
+        await self.run_task()
+
+        self.container_apps_client.jobs.begin_update.assert_not_awaited()
+        self.write_cache.assert_not_awaited()
+
+    async def test_updates_changed_component(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(ALL_JOBS)
+
+        await self.run_task()
+
+        self.container_apps_client.jobs.begin_update.assert_awaited_once_with(
+            "test_rg",
+            "resources-task-0863329b4b49",
+            AzureModelMatcher(
+                {"properties": {"template": {"containers": [{"name": "resources-task", "image": "2"}]}}}
+            ),
+        )
+        self.assertEqual(self.cache, {"resources": "2", "scaling": "1", "diagnostic_settings": "1"})
+
+    async def test_updates_multiple_components(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "2", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(ALL_JOBS)
+
+        await self.run_task()
+
+        self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 2)
+        self.assertEqual(self.cache, {"resources": "2", "scaling": "2", "diagnostic_settings": "1"})
+
+    async def test_no_private_manifest(self):
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
+        self.read_private_cache.return_value = ""
+        self.set_current_jobs(ALL_JOBS)
+
+        await self.run_task()
+
+        self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 3)
+        self.assertEqual(self.cache, public_cache)
+
+    async def test_invalid_public_manifest(self):
+        self.public_client.download_blob.return_value.readall.return_value = b"invalid"
+        self.read_private_cache.return_value = dumps({"resources": "1", "scaling": "1", "diagnostic_settings": "1"})
+        self.set_current_jobs(ALL_JOBS)
+
+        with self.assertRaises(InvalidCacheError) as ctx:
+            await self.run_task()
+
+        self.write_cache.assert_not_awaited()
+        self.public_client.download_blob.assert_awaited_once_with(TASK_IMAGES_MANIFEST_FILE_NAME)
+        self.assertEqual("Invalid Public Manifest: invalid", str(ctx.exception))
+
+    async def test_private_manifest_error(self):
+        public_cache: ManifestCache = {"resources": "2", "scaling": "1", "diagnostic_settings": "1"}
+        self.public_client.download_blob.return_value.readall.return_value = dumps(public_cache).encode()
+        self.read_private_cache.side_effect = Exception("storage error")
+        self.set_current_jobs(ALL_JOBS)
+
+        await self.run_task()
+
+        self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 3)
+        self.assertEqual(self.cache, public_cache)
+
+    async def test_job_not_found_skips_component(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(["scaling-task-0863329b4b49", "diagnostic-settings-task-0863329b4b49"])
+
+        await self.run_task()
+
+        self.container_apps_client.jobs.begin_update.assert_not_awaited()
+        self.write_cache.assert_not_awaited()
+
+    async def test_update_failure_skips_cache_write_for_component(self):
+        self.set_caches(
+            public_cache={"resources": "2", "scaling": "2", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(ALL_JOBS)
+        self.container_apps_client.jobs.begin_update.side_effect = [Exception("update failed"), AsyncMock()]
+
+        await self.run_task()
+
+        self.assertEqual(self.container_apps_client.jobs.begin_update.await_count, 2)
+
+    async def test_govcloud(self):
+        self.env[CONTROL_PLANE_REGION_SETTING] = "usgovarizona"
+        self.set_caches(
+            public_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(ALL_JOBS)
+
+        await self.run_task()
+
+        self.credential.get_token.assert_awaited_once_with("https://management.usgovcloudapi.net/.default")
+        self.container_apps_client.jobs.begin_update.assert_not_awaited()
+
+    async def test_tags(self):
+        self.env[CONTROL_PLANE_ID_SETTING] = "a2b4c5d6"
+        self.set_caches(
+            public_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+            private_cache={"resources": "1", "scaling": "1", "diagnostic_settings": "1"},
+        )
+        self.set_current_jobs(ALL_JOBS)
+
+        task = await self.run_task()
+
+        self.assertCountEqual(
+            task.tags,
+            [
+                "forwarder:lfocontrolplane",
+                "task:container_app_jobs_deployer_task",
+                "control_plane_id:a2b4c5d6",
+                f"version:{VERSION}",
+            ],
+        )

--- a/control_plane/tasks/tests/test_deployer_task.py
+++ b/control_plane/tasks/tests/test_deployer_task.py
@@ -17,7 +17,7 @@ from cache.env import (
     RESOURCE_GROUP_SETTING,
     SUBSCRIPTION_ID_SETTING,
 )
-from cache.manifest_cache import MANIFEST_CACHE_NAME, ManifestCache, deserialize_manifest_cache
+from cache.manifest_cache import TASK_ZIPS_MANIFEST_FILE_NAME, ManifestCache, deserialize_manifest_cache
 from tasks.deployer_task import DEPLOYER_TASK_NAME, DeployerTask
 from tasks.tests.common import AsyncMockClient, TaskTestCase, async_generator, mock
 from tasks.version import VERSION
@@ -34,7 +34,7 @@ class TestDeployerTask(TaskTestCase):
 
     @property
     def cache(self) -> ManifestCache:
-        return self.cache_value(MANIFEST_CACHE_NAME, deserialize_manifest_cache)
+        return self.cache_value(TASK_ZIPS_MANIFEST_FILE_NAME, deserialize_manifest_cache)
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-4759

Creates a new deployer task which controls updates of control plane tasks as Container App Jobs. The `deployer-caj` task works similarly to the original `deployer` task. It compares public and private manifest files and updates the control plane tasks. `deployer-caj` updates the images by [PATCHing](https://learn.microsoft.com/en-us/rest/api/resource-manager/containerapps/jobs/update?view=rest-resource-manager-containerapps-2026-01-01&tabs=HTTP) the container app jobs and updating the image name. 

Open to suggestions on the naming of everything.

Some details:
1. This is a new task published as a separate image from the original `deployer`. I considered modifying the original deployer and adding a code path to handle both Function Apps and CAJs, but the code is much simpler if they are separate tasks.
2. I created a new manifest file to track update of the CAJ control plane. I considered reusing the original `manifest.json`, but the schema of the file doesn't match what we need and it is simpler to just have a separate file.
3. Create a new publish.py file that publishes the public manifest file 
 

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

With the changes from https://github.com/DataDog/azure-log-forwarding-orchestration/pull/529, I was able to deploy working personal environment.

The resource task starts with the `:latest` image
<img width="680" height="160" alt="Screenshot 2026-06-29 at 10 57 52 AM" src="https://github.com/user-attachments/assets/5d1a99d6-b384-4791-a705-47be32298e5d" />

The deployer runs successfully:
<img width="674" height="318" alt="Screenshot 2026-06-29 at 11 03 50 AM" src="https://github.com/user-attachments/assets/e1e9970e-559f-4139-a5fe-c2450c7d1086" />


The tasks are updated to their latest sha
<img width="672" height="171" alt="Screenshot 2026-06-29 at 11 04 20 AM" src="https://github.com/user-attachments/assets/6cf04fad-ebb7-47d8-b897-3c26239b415a" />

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
