### PR TITLE
[AZINTS-4759] fix CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
   DOCKER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
   CI_IMAGE: registry.ddbuild.io/ci/azure-log-forwarding-orchestration-ci:latest
   INTERNAL_DOCKER_REGISTRY: registry.ddbuild.io/lfo
+  PUBLIC_DOCKER_REGISTRY: datadoghq.azurecr.io
   QA_DOCKER_REGISTRY: lfoqa.azurecr.io
 stages:
   - ci-image
@@ -150,7 +151,7 @@ publish-task-images:
     - diagnostic-settings-task-build-tagged
   script:
     - control_plane/scripts/publish_images.py https://ddazurelfo.blob.core.windows.net
-      $INTERNAL_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      $PUBLIC_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 # Uploads the uninstall script to the public storage account (manual)
 uninstall-script-publish:
   image: $CI_IMAGE
@@ -460,11 +461,11 @@ publish-task-images-qa:
     - export AZURE_CLIENT_SECRET=$(vault kv get -field=azureSecret
       kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
     - control_plane/scripts/publish_images.py https://lfoqa.blob.core.windows.net
-      $INTERNAL_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      $QA_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   needs:
-    - resources-task-build-tagged
-    - scaling-task-build-tagged
-    - diagnostic-settings-task-build-tagged
+    - resources-task-build-qa
+    - scaling-task-build-qa
+    - diagnostic-settings-task-build-qa
 # Deploys the QA environment using the latest published task artifacts
 deploy-qa-env:
   image: $CI_IMAGE
@@ -507,6 +508,51 @@ deployer-caj-build-qa:
       VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
       $QA_DOCKER_REGISTRY/deployer-caj:latest -f "ci/deployer-caj-task/Dockerfile"
       ./control_plane --push
+# Builds the resources-task image and pushes it to the QA registry
+resources-task-build-qa:
+  image: $DOCKER_IMAGE
+  stage: build
+  only:
+    refs:
+      - main
+  tags: ["arch:amd64"]
+  script:
+    - $(vault kv get -field=docker
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - docker buildx build --platform=linux/amd64 --build-arg
+      VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
+      $QA_DOCKER_REGISTRY/resources-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      -f "ci/resources-task/Dockerfile" ./control_plane --push
+# Builds the diagnostic-settings-task image and pushes it to the QA registry
+diagnostic-settings-task-build-qa:
+  image: $DOCKER_IMAGE
+  stage: build
+  only:
+    refs:
+      - main
+  tags: ["arch:amd64"]
+  script:
+    - $(vault kv get -field=docker
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - docker buildx build --platform=linux/amd64 --build-arg
+      VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
+      $QA_DOCKER_REGISTRY/diagnostic-settings-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      -f "ci/diagnostic-settings-task/Dockerfile" ./control_plane --push
+# Builds the scaling-task image and pushes it to the QA registry
+scaling-task-build-qa:
+  image: $DOCKER_IMAGE
+  stage: build
+  only:
+    refs:
+      - main
+  tags: ["arch:amd64"]
+  script:
+    - $(vault kv get -field=docker
+      kv/k8s/gitlab-runner/azure-log-forwarding-orchestration/qa)
+    - docker buildx build --platform=linux/amd64 --build-arg
+      VERSION_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" --tag
+      $QA_DOCKER_REGISTRY/scaling-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      -f "ci/scaling-task/Dockerfile" ./control_plane --push
 # Uploads the uninstall script to the QA storage account
 uninstall-script-publish-qa:
   image: $CI_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
   - build
   - publish-qa
   - publish
-  - publish-manifest
+  - publish-task-images-manifest
 # ------------- CI IMAGE -------------
 # Rebuilds the CI image used by all other jobs; run manually when ci/build-image/Dockerfile changes
 ci-build-image:
@@ -139,7 +139,7 @@ publish-tasks:
 # Publishes control plane task image manifest to the public storage account so deployer-caj knows which images to deploy (manual)
 publish-task-images:
   image: $CI_IMAGE
-  stage: publish-manifest
+  stage: publish-task-images-manifest
   tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ stages:
   - build
   - publish-qa
   - publish
+  - publish-manifest
 # ------------- CI IMAGE -------------
 # Rebuilds the CI image used by all other jobs; run manually when ci/build-image/Dockerfile changes
 ci-build-image:
@@ -138,7 +139,7 @@ publish-tasks:
 # Publishes control plane task image manifest to the public storage account so deployer-caj knows which images to deploy (manual)
 publish-task-images:
   image: $CI_IMAGE
-  stage: publish
+  stage: publish-manifest
   tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
@@ -146,9 +147,9 @@ publish-task-images:
   variables:
     KUBERNETES_POD_ANNOTATIONS_azure: cloud-iam.emissary.datadoghq.com/azure=88d13348-0530-418a-89c0-9caa32d59037
   needs:
-    - resources-task-build-tagged
-    - scaling-task-build-tagged
-    - diagnostic-settings-task-build-tagged
+    - resources-task-publish
+    - scaling-task-publish
+    - diagnostic-settings-task-publish
   script:
     - control_plane/scripts/publish_images.py https://ddazurelfo.blob.core.windows.net
       $PUBLIC_DOCKER_REGISTRY v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Resolving some CI-relates issues from Copilot in previous PR: https://github.com/DataDog/azure-log-forwarding-orchestration/pull/528

- publish-task-images was publishing a task-image manifest built from $INTERNAL_DOCKER_REGISTRY (registry.ddbuild.io/lfo), but deployer-caj running in customer subscriptions can only pull from datadoghq.azurecr.io (verified against a live deployment). Added PUBLIC_DOCKER_REGISTRY and pointed the job at it.
- publish-task-images-qa had the same bug for QA: it referenced $INTERNAL_DOCKER_REGISTRY, but QA's deployer-caj only has credentials for lfoqa.azurecr.io. Added resources-task-build-qa, diagnostic-settings-task-build-qa, and scaling-task-build-qa jobs (mirroring deployer-build-qa) to push the task images to $QA_DOCKER_REGISTRY, and updated the manifest publish step to match.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [x] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->
Images are not in use yet.

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
