### PR TITLE
[AZINTS-4778] add tests for uninstalling Container App Job control plane

### DIFF
--- a/control_plane/scripts/tests/test_uninstall.py
+++ b/control_plane/scripts/tests/test_uninstall.py
@@ -71,6 +71,15 @@ MOCK_UNKNOWN_ROLE_ASSIGNMENT = {
     "principalName": "",  # Empty principalName indicates "Unknown" role assignbment
 }
 
+# Container App Job control planes assign this role instead of relying on Function App identities,
+# but it's tagged with the same "ddlfo{id}" description convention as any other LFO role assignment.
+MOCK_CAJ_ROLE_ASSIGNMENT = {
+    "id": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments/role-caj-1",
+    "roleDefinitionName": "Container App Job Contributor",
+    "principalId": "principal-caj-1",
+    "principalName": "service-principal-caj-1",
+}
+
 MOCK_RESOURCE_IDS = [
     "/subscriptions/sub-1/resourceGroups/test-rg-1/providers/Microsoft.Storage/storageAccounts/storage1",
     "/subscriptions/sub-1/resourceGroups/test-rg-2/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -261,6 +270,17 @@ class TestUninstallScript(TestCase):
         call_args = self.az_mock.call_args[0][0]
         self.assertIn(f"ddlfo{CONTROL_PLANE_ID_1}", call_args)
         self.assertIn(f"ddlfo{CONTROL_PLANE_ID_2}", call_args)
+
+    def test_find_role_assignments_finds_container_app_job_role(self):
+        """Container App Job control plane role assignments are found the same way as Function App ones,
+        since the query filters by description tag rather than roleDefinitionName"""
+        self.az_mock.return_value = json.dumps([MOCK_CAJ_ROLE_ASSIGNMENT])
+
+        sub_id_to_name = {SUB_ID_1: SUB_NAME_1}
+        control_plane_ids = {CONTROL_PLANE_ID_1}
+        result = uninstall.find_role_assignments(sub_id_to_name, control_plane_ids)
+
+        self.assertEqual(result, {SUB_ID_1: [MOCK_CAJ_ROLE_ASSIGNMENT]})
 
     @mock_patch("uninstall.find_role_assignments")
     @mock_patch("uninstall.find_unknown_role_assignments")


### PR DESCRIPTION
## Description
<!--
- What behavior has been changed?
- Which services/components are affected, directly or indirectly?
- Why is the change important?
-->

Jira issue: https://datadoghq.atlassian.net/browse/AZINTS-4778

The uninstall script doesn't need any changes to support uninstalling Container App Job control plane tasks. It detects a control plane based on the `ddlfo` storage account, deletes the entire resource group, and deletes role assignments based on the `ddlfo` prefix in the description.

Add tests that verify that the uninstall script works for a CAJ control plane.

This change affects:
 - [ ] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [x] Uninstall Script
 - [ ] CI/Documentation

## Testing
<!--
How was this tested?
- Unit tests: Test should cover core behavior as well as edge cases.
- Manual testing: Link to dashboard, or screenshots of logs or output in the portal.
-->

Unit tests

Ran uninstall script on a CAJ LFO and it succeeded:
<img width="977" height="554" alt="Screenshot 2026-07-09 at 10 33 37 AM" src="https://github.com/user-attachments/assets/c57c2d87-093f-4970-808a-1e6ba5dd389b" />

## Rollout
<!--
We are now in Beta, customers are not expected to reinstall. Is this PR backwards compatible? If not, how will we handle the rollout?

A good way to test this is by freshly installing LFO, and then deploying your change to the personal environment.

If you are making ARM/bicep changes, ensure that re-deploying the arm template from a fresh install works as expected.
There should be no conflicts or other errors when re-deploying.
-->

 - [x] I have verified that this change is backwards compatible.
