### PR TITLE
Remove support for virtual machines

### DIFF
--- a/control_plane/scripts/tests/test_uninstall.py
+++ b/control_plane/scripts/tests/test_uninstall.py
@@ -82,7 +82,7 @@ MOCK_CAJ_ROLE_ASSIGNMENT = {
 
 MOCK_RESOURCE_IDS = [
     "/subscriptions/sub-1/resourceGroups/test-rg-1/providers/Microsoft.Storage/storageAccounts/storage1",
-    "/subscriptions/sub-1/resourceGroups/test-rg-2/providers/Microsoft.Compute/virtualMachines/vm1",
+    "/subscriptions/sub-1/resourceGroups/test-rg-2/providers/Microsoft.Network/loadbalancers/lb1",
 ]
 
 MOCK_DIAGNOSTIC_SETTINGS = {

--- a/control_plane/scripts/tests/test_uninstall.py
+++ b/control_plane/scripts/tests/test_uninstall.py
@@ -82,7 +82,7 @@ MOCK_CAJ_ROLE_ASSIGNMENT = {
 
 MOCK_RESOURCE_IDS = [
     "/subscriptions/sub-1/resourceGroups/test-rg-1/providers/Microsoft.Storage/storageAccounts/storage1",
-    "/subscriptions/sub-1/resourceGroups/test-rg-2/providers/Microsoft.Network/loadbalancers/lb1",
+    "/subscriptions/sub-1/resourceGroups/test-rg-2/providers/Microsoft.Network/loadBalancers/lb1",
 ]
 
 MOCK_DIAGNOSTIC_SETTINGS = {

--- a/control_plane/scripts/uninstall.py
+++ b/control_plane/scripts/uninstall.py
@@ -74,7 +74,6 @@ ALLOWED_TYPES_PER_PROVIDER: Final = {
     "Microsoft.CognitiveServices": {"accounts"},
     "Microsoft.Communication": {"CommunicationServices"},
     "microsoft.community": {"communityTrainings"},
-    "Microsoft.Compute": {"virtualMachines"},
     "Microsoft.ConfidentialLedger": {"ManagedCCF", "ManagedCCFs"},
     "Microsoft.ConnectedCache": {
         "CacheNodes",

--- a/control_plane/tasks/client/tests/test_resource_client.py
+++ b/control_plane/tasks/client/tests/test_resource_client.py
@@ -25,7 +25,7 @@ SUPPORTED_REGION_2 = "southafricanorth"
 CONTAINER_APPS_UNSUPPORTED_REGION = "newzealandnorth"
 UNSUPPORTED_REGION = "uae"
 resource1 = mock(
-    id="res1", name="1", location=SUPPORTED_REGION_1, type="Microsoft.Compute/virtualMachines", tags={"datadog": "true"}
+    id="res1", name="1", location=SUPPORTED_REGION_1, type="Microsoft.Network/loadbalancers", tags={"datadog": "true"}
 )
 resource2 = mock(
     id="res2", name="2", location=SUPPORTED_REGION_1, type="Microsoft.Network/applicationgateways", tags=None
@@ -45,24 +45,25 @@ class TestResourceClientHelpers(TestCase):
         )
 
     def test_should_ignore_resource_by_region(self):
-        vm_type = "Microsoft.Compute/virtualMachines"
-        vm_name = "vm1"
+        resource_type = "Microsoft.Network/loadbalancers"
+        resource_name = "lb1"
         # valid regions
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, vm_type, vm_name))
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_2, vm_type, vm_name))
-        self.assertFalse(should_ignore_resource(CONTAINER_APPS_UNSUPPORTED_REGION, vm_type, vm_name))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, resource_type, resource_name))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_2, resource_type, resource_name))
+        self.assertFalse(should_ignore_resource(CONTAINER_APPS_UNSUPPORTED_REGION, resource_type, resource_name))
 
         # invalid regions
-        self.assertTrue(should_ignore_resource(UNSUPPORTED_REGION, vm_type, vm_name))
-        self.assertTrue(should_ignore_resource("nonsense region that doesn't exist", vm_type, vm_name))
-        self.assertTrue(should_ignore_resource("global", vm_type, vm_name))
+        self.assertTrue(should_ignore_resource(UNSUPPORTED_REGION, resource_type, resource_name))
+        self.assertTrue(should_ignore_resource("nonsense region that doesn't exist", resource_type, resource_name))
+        self.assertTrue(should_ignore_resource("global", resource_type, resource_name))
 
     def test_should_ignore_resource_by_type(self):
         # valid types
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Compute/virtualMachines", "vm1"))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadbalancers", "lb1"))
         self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/applicationGateways", "ag1"))
 
         # invalid types
+        self.assertTrue(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Compute/virtualMachines", "vm1"))
         self.assertTrue(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Compute/Snapshots", "snap1"))
         self.assertTrue(
             should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.AlertsManagement/PrometheusRuleGroups", "prg1")
@@ -70,8 +71,8 @@ class TestResourceClientHelpers(TestCase):
 
     def test_should_ignore_resource_by_name(self):
         # normal resources
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Compute/virtualMachines", "vm1"))
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Compute/virtualMachines", "vm2"))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadbalancers", "lb1"))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadbalancers", "lb2"))
 
         # TODO (AZINTS-2763): ensure storage accounts are ignored
         # control plane resources
@@ -132,7 +133,7 @@ class TestResourceClient(IsolatedAsyncioTestCase):
     async def test_global_resource_ignored(self):
         self.mock_clients["ResourceManagementClient"].resources.list = mock(
             return_value=async_generator(
-                mock(id="res1", location="global", type="Microsoft.Compute/virtualMachines"),
+                mock(id="res1", location="global", type="Microsoft.Network/loadbalancers"),
                 mock(id="res2", location="global", type="Microsoft.Network/applicationGateways"),
             )
         )
@@ -287,7 +288,7 @@ class TestResourceClient(IsolatedAsyncioTestCase):
                     id="res_key_only",
                     name="1",
                     location=SUPPORTED_REGION_1,
-                    type="Microsoft.Compute/virtualMachines",
+                    type="Microsoft.Network/loadbalancers",
                     tags={"datadog": ""},
                 )
             )

--- a/control_plane/tasks/client/tests/test_resource_client.py
+++ b/control_plane/tasks/client/tests/test_resource_client.py
@@ -25,7 +25,7 @@ SUPPORTED_REGION_2 = "southafricanorth"
 CONTAINER_APPS_UNSUPPORTED_REGION = "newzealandnorth"
 UNSUPPORTED_REGION = "uae"
 resource1 = mock(
-    id="res1", name="1", location=SUPPORTED_REGION_1, type="Microsoft.Network/loadbalancers", tags={"datadog": "true"}
+    id="res1", name="1", location=SUPPORTED_REGION_1, type="Microsoft.Network/loadBalancers", tags={"datadog": "true"}
 )
 resource2 = mock(
     id="res2", name="2", location=SUPPORTED_REGION_1, type="Microsoft.Network/applicationgateways", tags=None
@@ -45,7 +45,7 @@ class TestResourceClientHelpers(TestCase):
         )
 
     def test_should_ignore_resource_by_region(self):
-        resource_type = "Microsoft.Network/loadbalancers"
+        resource_type = "Microsoft.Network/loadBalancers"
         resource_name = "lb1"
         # valid regions
         self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, resource_type, resource_name))
@@ -59,7 +59,7 @@ class TestResourceClientHelpers(TestCase):
 
     def test_should_ignore_resource_by_type(self):
         # valid types
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadbalancers", "lb1"))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadBalancers", "lb1"))
         self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/applicationGateways", "ag1"))
 
         # invalid types
@@ -71,8 +71,8 @@ class TestResourceClientHelpers(TestCase):
 
     def test_should_ignore_resource_by_name(self):
         # normal resources
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadbalancers", "lb1"))
-        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadbalancers", "lb2"))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadBalancers", "lb1"))
+        self.assertFalse(should_ignore_resource(SUPPORTED_REGION_1, "Microsoft.Network/loadBalancers", "lb2"))
 
         # TODO (AZINTS-2763): ensure storage accounts are ignored
         # control plane resources
@@ -133,7 +133,7 @@ class TestResourceClient(IsolatedAsyncioTestCase):
     async def test_global_resource_ignored(self):
         self.mock_clients["ResourceManagementClient"].resources.list = mock(
             return_value=async_generator(
-                mock(id="res1", location="global", type="Microsoft.Network/loadbalancers"),
+                mock(id="res1", location="global", type="Microsoft.Network/loadBalancers"),
                 mock(id="res2", location="global", type="Microsoft.Network/applicationGateways"),
             )
         )
@@ -288,7 +288,7 @@ class TestResourceClient(IsolatedAsyncioTestCase):
                     id="res_key_only",
                     name="1",
                     location=SUPPORTED_REGION_1,
-                    type="Microsoft.Network/loadbalancers",
+                    type="Microsoft.Network/loadBalancers",
                     tags={"datadog": ""},
                 )
             )

--- a/control_plane/tasks/constants.py
+++ b/control_plane/tasks/constants.py
@@ -34,7 +34,6 @@ UNNESTED_VALID_RESOURCE_TYPES: Final[frozenset[str]] = frozenset(
         "microsoft.cognitiveservices/accounts",
         "microsoft.communication/communicationservices",
         "microsoft.community/communitytrainings",
-        "microsoft.compute/virtualmachines",
         "microsoft.confidentialledger/managedccf",
         "microsoft.confidentialledger/managedccfs",
         "microsoft.connectedcache/cachenodes",

--- a/control_plane/tasks/tests/test_diagnostic_settings_task.py
+++ b/control_plane/tasks/tests/test_diagnostic_settings_task.py
@@ -36,8 +36,8 @@ region1: Final = "region1"
 config_id1: Final = "bc666ef914ec"
 control_plane_id: Final = "e90ecb54476d"
 DIAGNOSTIC_SETTING_NAME: Final = DIAGNOSTIC_SETTING_PREFIX + control_plane_id
-resource_id1: Final = "/subscriptions/1/resourcegroups/rg1/providers/microsoft.compute/virtualmachines/vm1"
-resource_id2: Final = "/subscriptions/1/resourcegroups/rg1/providers/microsoft.compute/virtualmachines/vm2"
+resource_id1: Final = "/subscriptions/1/resourcegroups/rg1/providers/microsoft.network/loadbalancers/lb1"
+resource_id2: Final = "/subscriptions/1/resourcegroups/rg1/providers/microsoft.network/loadbalancers/lb2"
 storage_account: Final = (
     f"/subscriptions/{sub_id1}/resourcegroups/lfo/providers/microsoft.storage/storageaccounts/ddlogstorage{config_id1}"
 )

--- a/control_plane/tasks/tests/test_resources_task.py
+++ b/control_plane/tasks/tests/test_resources_task.py
@@ -37,7 +37,7 @@ SUPPORTED_REGION_1 = "norwayeast"
 SUPPORTED_REGION_2 = "southafricanorth"
 CONTAINER_APPS_UNSUPPORTED_REGION = "newzealandnorth"
 UNSUPPORTED_REGION = "uae"
-resource1 = mock(id="res1", name="1", location=SUPPORTED_REGION_1, type="Microsoft.Compute/virtualMachines")
+resource1 = mock(id="res1", name="1", location=SUPPORTED_REGION_1, type="Microsoft.KeyVault/vaults")
 resource2 = mock(id="res2", name="2", location=SUPPORTED_REGION_1, type="Microsoft.Network/applicationgateways")
 resource3 = mock(id="res3", name="3", location=SUPPORTED_REGION_2, type="Microsoft.Network/loadBalancers")
 included_metadata = ResourceMetadata(include=True)


### PR DESCRIPTION
VMs doesn't seem to support diagnosticSettingsCategories API.                                                                                                              

[Diagnostic Settings in Azure Monitor - Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings?tabs=portal)                                                                                                                                                               

[Diagnostic Settings Category - List REST API](https://learn.microsoft.com/en-us/rest/api/monitor/diagnostic-settings-category/list?view=rest-monitor-2021-05-01-preview&tabs=HTTP&tryIt=true&source=docs#code-try-0)

There are also no Log table for VM.
[Supported log categories - Microsoft.Compute/virtualMachines - Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-logs/microsoft-compute-virtualmachines-logs)

-----

Recreates #518 on top of current main.

Original context:
VMs do not seem to support diagnosticSettingsCategories API.

References:
- Diagnostic Settings in Azure Monitor: https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings?tabs=portal
- Diagnostic Settings Category - List REST API: https://learn.microsoft.com/en-us/rest/api/monitor/diagnostic-settings-category/list?view=rest-monitor-2021-05-01-preview&tabs=HTTP&tryIt=true&source=docs#code-try-0
- Supported log categories - Microsoft.Compute/virtualMachines: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-logs/microsoft-compute-virtualmachines-logs

Verification:
- .venv/bin/python -m pytest control_plane/scripts/tests/test_uninstall.py control_plane/tasks/client/tests/test_resource_client.py control_plane/tasks/tests/test_diagnostic_settings_task.py control_plane/tasks/tests/test_resources_task.py
- .venv/bin/python -m ruff check control_plane/scripts/tests/test_uninstall.py control_plane/scripts/uninstall.py control_plane/tasks/client/tests/test_resource_client.py control_plane/tasks/constants.py control_plane/tasks/tests/test_diagnostic_settings_task.py control_plane/tasks/tests/test_resources_task.py
