### PR TITLE
Onboard off public-images GitLab job-token trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,25 @@ stages:
   - publish-qa
   - publish
   - publish-task-images-manifest
+# Shared job definition for publishing images via dd-pkg publish-image (artifact-gateway)
+.docker_publish_job_definition:
+  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  variables:
+    IMG_SIGNING: "false"
+    PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"
+  script:
+    - |
+      set -euo pipefail
+      dd-pkg version
+      args=(publish-image --timeout "${PUBLIC_IMAGES_PUBLISH_TIMEOUT}" --poll-interval 30 --signing="${IMG_SIGNING}")
+      if [[ -n "${IMG_REGISTRIES:-}" ]]; then args+=(--registries "${IMG_REGISTRIES}"); fi
+      if [[ -n "${IMG_SOURCES:-}" ]]; then args+=(--sources "${IMG_SOURCES}"); fi
+      if [[ -n "${IMG_DESTINATIONS:-}" ]]; then args+=(--destinations "${IMG_DESTINATIONS}"); fi
+      if [[ -n "${IMG_DESTINATIONS_REGEX:-}" ]]; then args+=(--regex-expression "${IMG_DESTINATIONS_REGEX}"); fi
+      if [[ -n "${IMG_DESTINATIONS_REGEX_REPL:-}" ]]; then args+=(--regex-replacement "${IMG_DESTINATIONS_REGEX_REPL}"); fi
+      if [[ -n "${IMG_TAG_REFERENCE:-}" ]]; then args+=(--tag-reference "${IMG_TAG_REFERENCE}"); fi
+      if [[ -n "${IMG_NEW_TAGS:-}" ]]; then args+=(--new-tags "${IMG_NEW_TAGS}"); fi
+      dd-pkg "${args[@]}"
 # ------------- CI IMAGE -------------
 # Rebuilds the CI image used by all other jobs; run manually when ci/build-image/Dockerfile changes
 ci-build-image:
@@ -187,10 +206,7 @@ deployer-publish:
       when: manual
   needs:
     - deployer-build-tagged
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: deployer:latest,deployer:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -217,10 +233,7 @@ deployer-caj-publish:
       when: manual
   needs:
     - deployer-caj-build-tagged
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: deployer-caj:latest,deployer-caj:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -247,10 +260,7 @@ resources-task-publish:
       when: manual
   needs:
     - resources-task-build-tagged
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/resources-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: resources-task:latest,resources-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -277,10 +287,7 @@ diagnostic-settings-task-publish:
       when: manual
   needs:
     - diagnostic-settings-task-build-tagged
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/diagnostic-settings-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: diagnostic-settings-task:latest,diagnostic-settings-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -307,10 +314,7 @@ scaling-task-publish:
       when: manual
   needs:
     - scaling-task-build-tagged
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/scaling-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: scaling-task:latest,scaling-task:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -354,10 +358,7 @@ forwarder-publish:
       when: manual
   needs:
     - forwarder-build-tagged
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $INTERNAL_DOCKER_REGISTRY/forwarder:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: forwarder:latest,forwarder:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ stages:
   - publish-task-images-manifest
 # Shared job definition for publishing images via dd-pkg publish-image (artifact-gateway)
 .docker_publish_job_definition:
-  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.3
   tags: ["arch:arm64"]
   variables:
     IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 # Shared job definition for publishing images via dd-pkg publish-image (artifact-gateway)
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
-  tags: ["arch:amd64"]
+  tags: ["arch:arm64"]
   variables:
     IMG_SIGNING: "false"
     PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ stages:
 # Shared job definition for publishing images via dd-pkg publish-image (artifact-gateway)
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  tags: ["arch:amd64"]
   variables:
     IMG_SIGNING: "false"
     PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"


### PR DESCRIPTION
Replaces the legacy `trigger: project: DataDog/public-images` job with a direct `dd-pkg publish-image` call against artifact-gateway.

## Why

The GitLab job-token bridge cannot tell **who** triggered a publish — any project holding a token could publish anything. Calling artifact-gateway instead adds:

- **Authentication** — the caller's identity is verified.
- **Authorization** — a policy states which Directory Service group may release each image tier (dev vs prod).
- An audit trail of every publication.

**Authorization is in audit-only mode for now** — nothing is blocked, publications are only recorded. So this is safe to merge, and the rollout stays reversible behind a feature flag.

Publish cadence, tags and destinations are unchanged; this is an onboarding change only.

- Jira: [BARX-1957](https://datadoghq.atlassian.net/browse/BARX-1957)
- How-to: [Publish public images with dd-pkg](https://datadoghq.atlassian.net/wiki/x/ooQkngE)

[BARX-1957]: https://datadoghq.atlassian.net/browse/BARX-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ