### PR TITLE
[CLOUDS-8523] Ensure forwarders deleted completely

### DIFF
--- a/control_plane/tasks/client/log_forwarder_client.py
+++ b/control_plane/tasks/client/log_forwarder_client.py
@@ -444,24 +444,38 @@ class LogForwarderClient(AbstractAsyncContextManager["LogForwarderClient"]):
                 extra=self.log_extra,
             )
 
-            # start deleting the storage account now, it has no dependencies
-            delete_storage_account_task = create_task(
-                ignore_exception_type(
+            async def _delete_job() -> None:
+                poller = await ignore_exception_type(
+                    ResourceNotFoundError,
+                    self.container_apps_client.jobs.begin_delete(
+                        self.resource_group, get_container_app_name(forwarder_id)
+                    ),
+                )
+                if poller:
+                    await poller.result()
+
+            async def _delete_storage_account() -> None:
+                await ignore_exception_type(
                     ResourceNotFoundError,
                     self.storage_client.storage_accounts.delete(
                         self.resource_group, get_storage_account_name(forwarder_id)
                     ),
                 )
-            )
 
-            poller = await ignore_exception_type(
-                ResourceNotFoundError,
-                self.container_apps_client.jobs.begin_delete(self.resource_group, get_container_app_name(forwarder_id)),
+            # run both deletes concurrently, but always wait for both so neither is left dangling
+            # if the other raises
+            maybe_errors = await gather(
+                _delete_job(),
+                _delete_storage_account(),
+                return_exceptions=True,
             )
-            if poller:
-                await poller.result()
-
-            await delete_storage_account_task
+            log_errors(
+                self.log,
+                f"Failed to delete log forwarder {forwarder_id}",
+                *maybe_errors,
+                reraise=True,
+                extra=self.log_extra,
+            )
             self.log.info("Deleted log forwarder %s", forwarder_id, extra=self.log_extra)
 
         try:

--- a/control_plane/tasks/client/tests/test_log_forwarder_client.py
+++ b/control_plane/tasks/client/tests/test_log_forwarder_client.py
@@ -396,6 +396,28 @@ class TestLogForwarderClient(AsyncTestCase):
             async with self.client as client:
                 await client.delete_log_forwarder(CONFIG_ID1)
 
+    async def test_delete_log_forwarder_still_awaits_storage_delete_when_job_delete_fails(self):
+        # Regression: the storage account delete used to be launched via a bare create_task()
+        # and only awaited *after* the job delete call. If the job delete raised something other
+        # than ResourceNotFoundError, the function returned via that exception without ever
+        # awaiting the storage delete task, silently leaking the storage account. A real Azure
+        # call isn't instant, so give the storage delete a small delay here too: a zero-delay
+        # mock can spuriously finish anyway during an incidental event-loop yield, masking the bug.
+        self.client.container_apps_client.jobs.begin_delete.side_effect = FakeHttpError(400)
+
+        async def _slow_delete(*args: object, **kwargs: object) -> None:
+            await sleep(0.05)
+
+        self.client.storage_client.storage_accounts.delete.side_effect = _slow_delete
+        async with self.client as client:
+            success = await client.delete_log_forwarder(CONFIG_ID1, raise_error=False, max_attempts=1)
+            # assert immediately, before exiting the `async with` block gives the event loop
+            # any more incidental opportunities to let a dangling task sneak in
+            self.assertFalse(success)
+            self.client.storage_client.storage_accounts.delete.assert_awaited_once_with(
+                RESOURCE_GROUP_NAME, STORAGE_ACCOUNT_NAME
+            )
+
     async def test_delete_log_forwarder_not_raise_error(self):
         self.client.container_apps_client.jobs.begin_delete.side_effect = FakeHttpError(400)
         async with self.client as client:


### PR DESCRIPTION
## Description
We are seeing some cases where the container app environment is broken due to Azure DC capacity problems. This is not something we can really fix, but of more immediate concern is that in some cases this has led to a proliferation of orphaned storage accounts. I believe this is because `delete_log_forwarder` is running into an unhandled error attempting to delete the (nonexistent) container app and killing the job completely, sometimes before storage account deletion can take place, since the latter is running asynchronously.

Jira issue: https://datadoghq.atlassian.net/browse/CLOUDS-8523

This change affects:
 - [x] Control Plane Tasks
 - [ ] Forwarder
 - [ ] ARM Templates (Bicep)
 - [ ] Uninstall Script
 - [ ] CI/Documentation

## Testing
Added unit tests and they pass. Issue would be hard to reproduce because it's flaky, but I'll try it out in a test environment to make sure this isn't breaking deletes in a more typical environment.

## Rollout
Customers will have to re-install to benefit from the fix.
